### PR TITLE
Support Windows System with Space in Path

### DIFF
--- a/script/bundled-node-version.js
+++ b/script/bundled-node-version.js
@@ -1,23 +1,73 @@
 const child_process = require('child_process')
 
 module.exports = function(filename, callback) {
-  child_process.exec(filename + ' -v', function(error, stdout) {
-    if (error != null) {
-      callback(error);
-      return;
-    }
+  if (process.platform === 'win32') {
+    // Due to windows shell handling using spawn here will allow better compatibility
+      callback(error);	    // for example if a user has a space in the path name, this causes every aspect of the build process to crash
+      return;	
+    }	
 
-    let version = null;
-    if (stdout != null) {
-      version = stdout.toString().trim();
-    }
+    let version = null;	    let version = null;
+    if (stdout != null) {	    let arch = null;
+      version = stdout.toString().trim();	
+    }	    const node_shell = child_process.spawn(`"${filename}"`, ['-v'], { shell: true });
 
-    child_process.exec(filename + " -p 'process.arch'", function(error, stdout) {
-      let arch = null;
-      if (stdout != null) {
-        arch = stdout.toString().trim();
+    node_shell.stderr.on('data', (error) => {
+      callback(error.toString());
+    });
+
+    node_shell.stdout.on('data', (data) => {
+      if (data != null) {
+        version = data.toString().trim();
       }
-      callback(error, version, arch);
-    })
-  });
+    });
+
+    node_shell.on('close', (code) => {
+      if (code !== 0) {
+        callback(`${filename} -v' Exited with: ${code}`);
+      }
+    });
+
+    const arch_shell = child_process.spawn(`"${filename}"`, ['-p', 'process.arch'], { shell: true });
+
+    arch_shell.stderr.on('data', (error) => {
+      callback(error.toString());
+    });
+
+    arch_shell.stdout.on('data', (data) => {
+      if (data != null) {
+        arch = data.toString().trim();
+      }
+
+      console.log(`Version: ${version}`);
+      console.log(`Arch: ${arch}`);
+      callback(null, version, arch);
+    });
+
+    arch_shell.on('close', (code) => {
+      if (code !== 0) {
+        callback(`'${filename} -p process.arch' Exited with: ${code}`);
+      }
+    });
+  } else {
+    child_process.exec(filename + ' -v', function(error, stdout) {
+      if (error != null) {
+        callback(error);
+        return;
+      }
+  
+      let version = null;
+      if (stdout != null) {
+        version = stdout.toString().trim();
+      }
+  
+      child_process.exec(filename + " -p 'process.arch'", function(error, stdout) {
+        let arch = null;
+        if (stdout != null) {
+          arch = stdout.toString().trim();
+        }
+        callback(error, version, arch);
+      })
+    });
+  }
 }

--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -18,6 +18,6 @@ fs.chmodSync(script, 0o755)
 fs.chmodSync(path.join(__dirname, '..', 'bin', 'apm'), 0o755)
 fs.chmodSync(path.join(__dirname, '..', 'bin', 'npm'), 0o755)
 
-const child = cp.spawn(script, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true })
+const child = cp.spawn(`"${script}"`, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true })
 child.stderr.pipe(process.stderr)
 child.stdout.pipe(process.stdout)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Previously if PPM was installed on a windows system with a space in the path, `postinstall` scripts and most other scripts would fail nearly immediately. These changes add support for this edge case.

### Benefits

<!-- What benefits will be realized by the code change? -->
This allows better support for developing on more systems.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
This may have edge case issues on other Operating Systems.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->
Prior to these changes PPM was uninstall able on a system experiencing this edge case, meanwhile now its fully supported to see test status, etc.

