### PR TITLE
Added Our Backend

### DIFF
--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -73,7 +73,7 @@ module.exports =
     process.env.ATOM_PACKAGES_URL ? "#{@getAtomApiUrl()}/packages"
 
   getAtomApiUrl: ->
-    process.env.ATOM_API_URL ? 'https://atom.io/api'
+    process.env.ATOM_API_URL ? 'https://pulsar-edit.com/api'
 
   getElectronArch: ->
     switch process.platform


### PR DESCRIPTION
With the `Atom.io` API becoming more and more unstable, taking a long time to return, failing to return, or just straight up failing to resolve.

So this PR adds our 'beta' Backend. 

This is the backend that I've been working on since the announcement of the sunset, and while currently unfinished, would allow users to search, query, and install all packages that were originally on the Atom.io Package Repository.

While this PR is simple the implications are large. Feel free to discuss the change.

Additionally since PPM is a submodule in `Pulsar` that means as soon as this is committed, any additional builds of Pulsar should automatically get this update.