### PR TITLE
ci: Use 'windows-2019' image for Windows tests (makes CI passing)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
+          - windows-2019
         node_version:
           - 14
           - 16


### PR DESCRIPTION
The fix is copied from https://github.com/atom/github/pull/2758:

> This gives us an older version of Visual Studio compatible with apm's old copy of node-gyp, so CI can proceed past installing dependencies/not get stuck, on the Windows jobs.
>
> (context: ppm is still built around npm 6 --> node-gyp 5.x. Visual Studio 2022 support was only added in [node-gyp 8.4.0](https://github.com/nodejs/node-gyp/blob/master/CHANGELOG.md#840-2021-11-05). So we need an older Visual Studio to accommodate ppm's old copy of node-gyp. the 'windows-2019' image has the older Visual Studio we're looking for.)