### PR TITLE
Use ppm as basename in getResourcePath checks

### DIFF
--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -30,14 +30,14 @@ module.exports =
 
     apmFolder = path.resolve(__dirname, '..')
     appFolder = path.dirname(apmFolder)
-    if path.basename(apmFolder) is 'apm' and path.basename(appFolder) is 'app'
+    if path.basename(apmFolder) is 'ppm' and path.basename(appFolder) is 'app'
       asarPath = "#{appFolder}.asar"
       if fs.existsSync(asarPath)
         return process.nextTick -> callback(asarPath)
 
     apmFolder = path.resolve(__dirname, '..', '..', '..')
     appFolder = path.dirname(apmFolder)
-    if path.basename(apmFolder) is 'apm' and path.basename(appFolder) is 'app'
+    if path.basename(apmFolder) is 'ppm' and path.basename(appFolder) is 'app'
       asarPath = "#{appFolder}.asar"
       if fs.existsSync(asarPath)
         return process.nextTick -> callback(asarPath)


### PR DESCRIPTION
This fixes the issue with core packages not showing in settings view caused by the change of `apm` install folder to `ppm` in pulsar-edit/pulsar#125.