### PR TITLE
Fix empty featured packages

### DIFF
--- a/src/featured.coffee
+++ b/src/featured.coffee
@@ -37,7 +37,7 @@ class Featured extends Command
       if error?
         callback(error)
       else if response.statusCode is 200
-        packages = body.filter (pack) -> pack?.releases?.latest?
+        packages = body.filter (pack) -> pack?.releases?
         packages = packages.map ({readme, metadata, downloads, stargazers_count}) -> _.extend({}, metadata, {readme, downloads, stargazers_count})
         packages = _.sortBy(packages, 'name')
         callback(null, packages)


### PR DESCRIPTION
This fixes #37 and pulsar-edit/pulsar#137 by not checking for `latest` key in `releases`. If the issue pulsar-edit/package-backend#3 is fixed, then this PR can be rejected.