### PR TITLE
src: Update Electron header download URL

### DIFF
--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -67,7 +67,7 @@ module.exports =
     process.env.ATOM_REPOS_HOME ? path.join(@getHomeDirectory(), 'github')
 
   getElectronUrl: ->
-    process.env.ATOM_ELECTRON_URL ? 'https://atom.io/download/electron'
+    process.env.ATOM_ELECTRON_URL ? 'https://artifacts.electronjs.org/headers/dist'
 
   getAtomPackagesUrl: ->
     process.env.ATOM_PACKAGES_URL ? "#{@getAtomApiUrl()}/packages"


### PR DESCRIPTION
The old atom.io Electron headers URL is going down, per the updated sunset announcement.

Likewise, the old gh-contractor-zcbenz Amazon AWS/S3 bucket is no-longer guaranteed to be active, and may go away at any time.

(See: https://github.blog/2022-06-08-sunsetting-atom/#if-im-using-atom-what-changes-can-i-expect-after-the-sunset and https://www.electronjs.org/blog/s3-bucket-change)

So, this commit updates our package manager to get the Electron headers from the new 'artifacts.electronjs.org/headers/dist' location.

This is the correct, official place to get the Electron headers, according to the blog post above at electronjs.org.

Ensures we can continue to build native C/C++ code for certain Atom/Pulsar packages that use it.

(For example: several of the language packages have C/C++ addon code.)