### PR TITLE
Convert body params to query params

### DIFF
--- a/src/publish.coffee
+++ b/src/publish.coffee
@@ -153,7 +153,7 @@ class Publish extends Command
         requestSettings =
           url: config.getAtomPackagesUrl()
           json: true
-          body:
+          qs:
             repository: repository
           headers:
             authorization: token
@@ -183,7 +183,7 @@ class Publish extends Command
       requestSettings =
         url: "#{config.getAtomPackagesUrl()}/#{packageName}/versions"
         json: true
-        body:
+        qs:
           tag: tag
           rename: options.rename
         headers:


### PR DESCRIPTION
This is a REQUIREMENT for package publishing on the Pulsar backend.

The original Atom documentation had a section "parameters" where they did not clarify whether they were using form parameters, or query parameters. Due to the language we assumed that it was query parameters.

See here in the Discord for context: https://discord.com/channels/992103415163396136/992110095641088001/

The submodule within Pulsar will need to be updated to point to the new hash once this has been merged