### PR TITLE
Fix .com links, pulsar rebranding and rebranding readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See the [Atom contributing guide](https://github.com/atom/atom/blob/master/CONTRIBUTING.md)
+See the [Pulsar contributing guide](https://github.com/pulsar-edit/.github/blob/main/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -1,23 +1,22 @@
-# apm - Atom Package Manager
+# ppm - Pulsar Package Manager
 
-![Build Status](https://github.com/atom-ide-community/apm/workflows/CI/badge.svg)
-[![Dependency Status](https://david-dm.org/atom/apm.svg)](https://david-dm.org/atom/apm)
+Discover and install Pulsar packages powered by [pulsar-edit.dev](https://web.pulsar-edit.dev).
 
-Discover and install Atom packages powered by [atom.io](https://atom.io)
+ppm is bundled with the `pulsar` binaries so any ppm command can also be run with `pulsar -p` or `pulsar --package`.
 
-You can configure apm by using the `apm config` command line option (recommended) or by manually editing the `~/.atom/.apmrc` file as per the [npm config](https://docs.npmjs.com/misc/config).
+You can configure ppm by using the `ppm config` command line option (recommended) or by manually editing the `~/.pulsar/.apmrc` file as per the [npm config](https://docs.npmjs.com/misc/config).
 
 ## Relation to npm
 
-apm bundles [npm](https://github.com/npm/npm) with it and spawns `npm` processes to install Atom packages. The major difference is that `apm` sets multiple command line arguments to `npm` to ensure that native modules are built against Chromium's v8 headers instead of node's v8 headers.
+ppm bundles [npm](https://github.com/npm/npm) with it and spawns `npm` processes to install Pulsar packages. The major difference is that `ppm` sets multiple command line arguments to `npm` to ensure that native modules are built against Chromium's v8 headers instead of node's v8 headers.
 
-The other major difference is that Atom packages are installed to `~/.atom/packages` instead of a local `node_modules` folder and Atom packages are published to and installed from GitHub repositories instead of [npmjs.com](https://www.npmjs.com/)
+The other major difference is that Pulasr packages are installed to `~/.pulsar/packages` instead of a local `node_modules` folder and Pulsar packages are published to and installed from GitHub repositories instead of [npmjs.com](https://www.npmjs.com/)
 
-Therefore you can think of `apm` as a simple `npm` wrapper that builds on top of the many strengths of `npm` but is customized and optimized to be used for Atom packages.
+Therefore you can think of `ppm` as a simple `npm` wrapper that builds on top of the many strengths of `npm` but is customized and optimized to be used for Pulsar packages.
 
 ## Installing
 
-`apm` is bundled and installed automatically with Atom. You can run the _Atom > Install Shell Commands_ menu option to install it again if you aren't able to run it from a terminal (macOS only).
+`ppm` is bundled and installed automatically with Pulsar. You can run the _Pulsar > Install Shell Commands_ menu option to install it again if you aren't able to run it from a terminal (macOS only).
 
 ## Building
 
@@ -29,16 +28,16 @@ Therefore you can think of `apm` as a simple `npm` wrapper that builds on top of
 
 ### Why `bin/npm` / `bin\npm.cmd`?
 
-`apm` includes `npm`, and spawns it for various processes. It also comes with a bundled version of Node, and this script ensures that npm uses the right version of Node for things like running the tests. If you're using the same version of Node as is listed in `BUNDLED_NODE_VERSION`, you can skip using this script.
+`ppm` includes `npm`, and spawns it for various processes. It also comes with a bundled version of Node, and this script ensures that npm uses the right version of Node for things like running the tests. If you're using the same version of Node as is listed in `BUNDLED_NODE_VERSION`, you can skip using this script.
 
 ## Using
 
-Run `apm help` to see all the supported commands and `apm help <command>` to
+Run `ppm help` to see all the supported commands and `ppm help <command>` to
 learn more about a specific command.
 
-The common commands are `apm install <package_name>` to install a new package,
-`apm featured` to see all the featured packages, and `apm publish` to publish
-a package to [atom.io](https://atom.io).
+The common commands are `ppm install <package_name>` to install a new package,
+`ppm featured` to see all the featured packages, and `ppm publish` to publish
+a package to [pulsar-edit.dev](https://web.pulsar-edit.dev).
 
 ## Two-factor authentication?
 
@@ -50,19 +49,19 @@ If you are behind a firewall and seeing SSL errors when installing packages
 you can disable strict SSL by running:
 
 ```
-apm config set strict-ssl false
+ppm config set strict-ssl false
 ```
 
 ## Using a proxy?
 
-If you are using a HTTP(S) proxy you can configure `apm` to use it by running:
+If you are using a HTTP(S) proxy you can configure `ppm` to use it by running:
 
 ```
-apm config set https-proxy https://9.0.2.1:0
+ppm config set https-proxy https://9.0.2.1:0
 ```
 
-You can run `apm config get https-proxy` to verify it has been set correctly.
+You can run `ppm config get https-proxy` to verify it has been set correctly.
 
 ## Viewing configuration
 
-You can also run `apm config list` to see all the custom config settings.
+You can also run `ppm config list` to see all the custom config settings.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can configure ppm by using the `ppm config` command line option (recommended
 
 ppm bundles [npm](https://github.com/npm/npm) with it and spawns `npm` processes to install Pulsar packages. The major difference is that `ppm` sets multiple command line arguments to `npm` to ensure that native modules are built against Chromium's v8 headers instead of node's v8 headers.
 
-The other major difference is that Pulasr packages are installed to `~/.pulsar/packages` instead of a local `node_modules` folder and Pulsar packages are published to and installed from GitHub repositories instead of [npmjs.com](https://www.npmjs.com/)
+The other major difference is that Pulsar packages are installed to `~/.pulsar/packages` instead of a local `node_modules` folder and Pulsar packages are published to and installed from GitHub repositories instead of [npmjs.com](https://www.npmjs.com/)
 
 Therefore you can think of `ppm` as a simple `npm` wrapper that builds on top of the many strengths of `npm` but is customized and optimized to be used for Pulsar packages.
 

--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -66,7 +66,7 @@ parseOptions = (args=[]) ->
   options = yargs(args).wrap(Math.min(100, yargs.terminalWidth()))
   options.usage """
 
-  Pulsar Package Manager powered by https://pulsar-edit.com
+  Pulsar Package Manager powered by https://pulsar-edit.dev
 
     Usage: pulsar --package <command>
 

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -123,7 +123,7 @@ module.exports =
         ; This file is auto-generated and should not be edited since any
         ; modifications will be lost the next time any apm command is run.
         ;
-        ; You should instead edit your .apmrc config located in ~/.atom/.apmrc
+        ; You should instead edit your .apmrc config located in ~/.pulsar/.apmrc
         cache = #{@getCacheDirectory()}
         ; Hide progress-bar to prevent npm from altering apm console output.
         progress = false

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -73,7 +73,7 @@ module.exports =
     process.env.ATOM_PACKAGES_URL ? "#{@getAtomApiUrl()}/packages"
 
   getAtomApiUrl: ->
-    process.env.ATOM_API_URL ? 'https://pulsar-edit.com/api'
+    process.env.ATOM_API_URL ? 'https://api.pulsar-edit.dev/api'
 
   getElectronArch: ->
     switch process.platform

--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -9,7 +9,7 @@ catch error
   else
     throw error
 
-tokenName = 'Atom.io API Token'
+tokenName = 'pulsar-edit.dev API Token'
 
 module.exports =
   # Get the package API token from the keychain.
@@ -36,4 +36,4 @@ module.exports =
   #
   # token - A string token to save.
   saveToken: (token) ->
-    keytar.setPassword(tokenName, 'atom.io', token)
+    keytar.setPassword(tokenName, 'pulsar-edit.dev', token)

--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -9,7 +9,7 @@ catch error
   else
     throw error
 
-tokenName = 'pulsar-edit.dev API Token'
+tokenName = 'pulsar-edit.dev Package API Token'
 
 module.exports =
   # Get the package API token from the keychain.

--- a/src/featured.coffee
+++ b/src/featured.coffee
@@ -18,11 +18,11 @@ class Featured extends Command
              apm featured --themes
              apm featured --compatible 0.49.0
 
-      List the Atom packages and themes that are currently featured.
+      List the Pulsar packages and themes that are currently featured.
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
     options.alias('t', 'themes').boolean('themes').describe('themes', 'Only list themes')
-    options.alias('c', 'compatible').string('compatible').describe('compatible', 'Only list packages/themes compatible with this Atom version')
+    options.alias('c', 'compatible').string('compatible').describe('compatible', 'Only list packages/themes compatible with this Pulsar version')
     options.boolean('json').describe('json', 'Output featured packages as JSON array')
 
   getFeaturedPackagesByType: (atomVersion, packageType, callback) ->
@@ -64,9 +64,9 @@ class Featured extends Command
         console.log(JSON.stringify(packages))
       else
         if options.argv.themes
-          console.log "#{'Featured Atom Themes'.cyan} (#{packages.length})"
+          console.log "#{'Featured Pulsar Themes'.cyan} (#{packages.length})"
         else
-          console.log "#{'Featured Atom Packages'.cyan} (#{packages.length})"
+          console.log "#{'Featured Pulsar Packages'.cyan} (#{packages.length})"
 
         tree packages, ({name, version, description, downloads, stargazers_count}) ->
           label = name.yellow
@@ -75,7 +75,7 @@ class Featured extends Command
           label
 
         console.log()
-        console.log "Use `apm install` to install them or visit #{'http://atom.io/packages'.underline} to read more about them."
+        console.log "Use `apm install` to install them or visit #{'https://web.pulsar-edit.dev/'.underline} to read more about them."
         console.log()
 
       callback()

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -40,7 +40,7 @@ class Install extends Command
              apm install --packages-file my-packages.txt
              apm i (with any of the previous argument usage)
 
-      Install the given Atom package to ~/.atom/packages/<package_name>.
+      Install the given Atom package to ~/.pulsar/packages/<package_name>.
 
       If no package name is given then all the dependencies in the package.json
       file are installed to the node_modules folder in the current working

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -40,7 +40,7 @@ class Install extends Command
              apm install --packages-file my-packages.txt
              apm i (with any of the previous argument usage)
 
-      Install the given Atom package to ~/.pulsar/packages/<package_name>.
+      Install the given Pulsar package to ~/.pulsar/packages/<package_name>.
 
       If no package name is given then all the dependencies in the package.json
       file are installed to the node_modules folder in the current working

--- a/src/link.coffee
+++ b/src/link.coffee
@@ -17,13 +17,13 @@ class Link extends Command
 
       Usage: apm link [<package_path>] [--name <package_name>]
 
-      Create a symlink for the package in ~/.atom/packages. The package in the
+      Create a symlink for the package in ~/.pulsar/packages. The package in the
       current working directory is linked if no path is given.
 
       Run `apm links` to view all the currently linked packages.
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
-    options.alias('d', 'dev').boolean('dev').describe('dev', 'Link to ~/.atom/dev/packages')
+    options.alias('d', 'dev').boolean('dev').describe('dev', 'Link to ~/.pulsar/dev/packages')
 
   run: (options) ->
     {callback} = options

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -49,11 +49,11 @@ class Login extends Command
     return Q(state) if state.token
 
     welcome = """
-      Welcome to Atom!
+      Welcome to Pulsar!
 
       Before you can publish packages, you'll need an API token.
 
-      Visit your account page on Atom.io #{'https://atom.io/account'.underline},
+      Visit your account page on pulsar-edit.dev #{'https://web.pulsar-edit.dev/users'.underline},
       copy the token and paste it below when prompted.
 
     """
@@ -64,7 +64,7 @@ class Login extends Command
   openURL: (state) ->
     return Q(state) if state.token
 
-    open('https://atom.io/account')
+    open('https://web.pulsar-edit.dev/users')
 
   getToken: (state) =>
     return Q(state) if state.token

--- a/src/publish.coffee
+++ b/src/publish.coffee
@@ -224,7 +224,7 @@ class Publish extends Command
     if process.platform is 'darwin'
       process.stdout.write ' \uD83D\uDC4D  \uD83D\uDCE6  \uD83C\uDF89'
 
-    process.stdout.write "\nCheck it out at https://atom.io/packages/#{pack.name}\n"
+    process.stdout.write "\nCheck it out at https://web.pulsar-edit.dev/packages/#{pack.name}\n"
 
   loadMetadata: ->
     metadataPath = path.resolve('package.json')

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -81,7 +81,7 @@ class Search extends Command
           label
 
         console.log()
-        console.log "Use `apm install` to install them or visit #{'http://atom.io/packages'.underline} to read more about them."
+        console.log "Use `apm install` to install them or visit #{'https://pulsar-edit.dev'.underline} to read more about them."
         console.log()
 
       callback()

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -81,7 +81,7 @@ class Search extends Command
           label
 
         console.log()
-        console.log "Use `apm install` to install them or visit #{'https://pulsar-edit.dev'.underline} to read more about them."
+        console.log "Use `apm install` to install them or visit #{'https://web.pulsar-edit.dev'.underline} to read more about them."
         console.log()
 
       callback()

--- a/src/stars.coffee
+++ b/src/stars.coffee
@@ -83,7 +83,7 @@ class Stars extends Command
       label
 
     console.log()
-    console.log "Use `apm stars --install` to install them all or visit #{'http://atom.io/packages'.underline} to read more about them."
+    console.log "Use `apm stars --install` to install them all or visit #{'https://pulsar-edit.dev'.underline} to read more about them."
     console.log()
     callback()
 

--- a/src/stars.coffee
+++ b/src/stars.coffee
@@ -83,7 +83,7 @@ class Stars extends Command
       label
 
     console.log()
-    console.log "Use `apm stars --install` to install them all or visit #{'https://pulsar-edit.dev'.underline} to read more about them."
+    console.log "Use `apm stars --install` to install them all or visit #{'https://web.pulsar-edit.dev'.underline} to read more about them."
     console.log()
     callback()
 


### PR DESCRIPTION
Mostly this just fixes a few links:

- Org .github CONTRIBUTING.md link
- Update of `.com` to `.dev` links

However I also did a quick rebrand of the readme at the same time and I'm not sure if this is technically correct or not.

Elsewhere in the documentation we almost exclusively use `pulsar -p` as the "new" alias of `apm`.

However here it makes sense to keep the "direct" style of command in my mind. However this is where there is an issue because the binary itself is still `apm`.

So what I've done is change all `apm` instances to `ppm` in the style of https://github.com/pulsar-edit/pulsar/pull/273 this PR that is meant to add `ppm` to the PATH.

However this is also still correct if we used `apm` if we were talking about executing the binary directly so I don't know what the correct answer is here - feel free to make suggestions as to what we should do here. There are a *lot* of ppm command outputs that still talk about `apm` commands so whatever we choose here is also what we should be rolling out to the rest in a future pr.