### PR TITLE
src: Update default Pulsar install paths

### DIFF
--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -44,21 +44,16 @@ module.exports =
 
     switch process.platform
       when 'darwin'
-        child_process.exec 'mdfind "kMDItemCFBundleIdentifier == \'com.github.atom\'"', (error, stdout='', stderr) ->
+        child_process.exec 'mdfind "kMDItemCFBundleIdentifier == \'dev.pulsar-edit.pulsar\'"', (error, stdout='', stderr) ->
           [appLocation] = stdout.split('\n') unless error
-          appLocation = '/Applications/Atom.app' unless appLocation
+          appLocation = '/Applications/Pulsar.app' unless appLocation
           asarPath = "#{appLocation}/Contents/Resources/app.asar"
           return process.nextTick -> callback(asarPath)
       when 'linux'
-        asarPath = '/usr/local/share/atom/resources/app.asar'
-        unless fs.existsSync(asarPath)
-          asarPath = '/usr/share/atom/resources/app.asar'
+        asarPath = '/opt/Pulsar/resources/app.asar'
         return process.nextTick -> callback(asarPath)
       when 'win32'
-        glob = require 'glob'
-        pattern = "/Users/#{process.env.USERNAME}/AppData/Local/atom/app-+([0-9]).+([0-9]).+([0-9])/resources/app.asar"
-        asarPaths = glob.sync(pattern, null) # [] | a sorted array of locations with the newest version being last
-        asarPath = asarPaths[asarPaths.length - 1]
+        asarPath = "/Users/#{process.env.USERNAME}/AppData/Local/Programs/pulsar/resources/app.asar"
         return process.nextTick -> callback(asarPath)
       else
         return process.nextTick -> callback('')

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -54,6 +54,8 @@ module.exports =
         return process.nextTick -> callback(asarPath)
       when 'win32'
         asarPath = "/Users/#{process.env.USERNAME}/AppData/Local/Programs/pulsar/resources/app.asar"
+        unless fs.existsSync(asarPath)
+          asarPath = "/Program Files/Pulsar/resources/app.asar"
         return process.nextTick -> callback(asarPath)
       else
         return process.nextTick -> callback('')

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -53,7 +53,7 @@ module.exports =
         asarPath = '/opt/Pulsar/resources/app.asar'
         return process.nextTick -> callback(asarPath)
       when 'win32'
-        asarPath = "/Users/#{process.env.USERNAME}/AppData/Local/Programs/pulsar/resources/app.asar"
+        asarPath = "/Users/#{process.env.USERNAME}/AppData/Local/Programs/Pulsar/resources/app.asar"
         unless fs.existsSync(asarPath)
           asarPath = "/Program Files/Pulsar/resources/app.asar"
         return process.nextTick -> callback(asarPath)


### PR DESCRIPTION
   Changes:

Updates the default install paths for each OS, based on where our new bundled packages (made by electron-builder) install to.

Relatedly, adjust logic which finds the app on macOS, for the rebrand.

---

   Notes:

- A relative path from ppm's install dir in the bundled package is tried first, and then the default absolute install path of the whole app is hard-coded as a fallback. The relative path should work for any fully bundled/packaged copy of Pulsar.
- **This hard-coded fallback shouldn't be needed in actual installs of Pulsar -- this commit is mostly useful for situations where ppm is not bundled with the editor, such as when developing or testing ppm in the context of its own git repo.**
- on macOS, ppm also uses a search-on-disk "mdfind" command to find other potential install paths, before the hard-coded one, for whatever historical reason.

---

   Context:

This install path is used primarily to locate and read the editor's package.json, which gives various useful metadata for ppm to use, but also to find whatever files are needed from the editor bundle.

For example: this metadata is notably used to determine what Electron version to build native C/C++ code for, in whatever packages ppm is used to build.

(ppm reads the "electronVersion" field from Pulsar's package.json, which is located in Pulsar's "app.asar" bundle.)
(See: src/command.coffee)

Pulsar's package.json is also read to get Pulsar's version number. (See: src/command.coffee, src/apm-cli.coffee)

It is also read to get the list of bundled packages in the editor. (See: src/install.coffee, src/list.coffee)

The install path is also used to find/load the src/compile-cache.js module from among the editor's own source files.
(See: src/install.coffee)

Likewise, it is used to find/load the src/module-cache.js module from among the editor's own source files.
(See: src/rebuild-module-cache.coffee)