### PR TITLE
Update pulsar-edit package API URL and help/usage text URL

### DIFF
--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -66,7 +66,7 @@ parseOptions = (args=[]) ->
   options = yargs(args).wrap(Math.min(100, yargs.terminalWidth()))
   options.usage """
 
-  Pulsar Package Manager powered by https://pulsar-edit.com
+  Pulsar Package Manager powered by https://pulsar-edit.dev
 
     Usage: pulsar --package <command>
 

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -73,7 +73,7 @@ module.exports =
     process.env.ATOM_PACKAGES_URL ? "#{@getAtomApiUrl()}/packages"
 
   getAtomApiUrl: ->
-    process.env.ATOM_API_URL ? 'https://pulsar-edit.com/api'
+    process.env.ATOM_API_URL ? 'https://api.pulsar-edit.dev/api'
 
   getElectronArch: ->
     switch process.platform


### PR DESCRIPTION
Update URLs in ppm to point to pulsar-edit.dev, **not** pulsar-edit.com. (I am told pulsar-edit.com will be going away on or around the 29th of June 2023.)

- Update the package API URL from `https://pulsar-edit.com/api` to `https://api.pulsar-edit.dev/api`
- Update the `--help` / usage text text to say "powered by https://pulsar-edit.dev" instead of "powered by https://pulsar-edit.com"
  - I figure the package experience is split across `web.pulsar-edit.dev` (package frontend) and `api.pulsar-edit.dev` (package backend API). So split the difference and don't specify which of these.