### PR TITLE
meta: Normalize package.json and lockfile line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,8 @@ bin/npm text eol=lf
 
 # Batch files (Windows-style line endings)
 *.cmd   text eol=crlf
+
+# Normalize package metadata line endings, so we don't get large, line-ending-only diffs when edited on different OSes
+/package.json		text eol=lf
+/package-lock.json	text eol=lf
+/yarn.lock		text eol=lf


### PR DESCRIPTION
Prevents large, line-ending-only diffs when package metadata (mostly the dependencies) are updated on various OSes/platforms.

Especially Windows (CRLF) vs macOS/Linux (LF).

<details><summary>Why do this PR? (click to expand):</summary>

_(This was a rare but very annoying issue that cropped up _very infrequently_ over at upstream (official Atom team) apm and at atom-community/apm repos.)_

_(It hasn't been a problem here so far, and maybe it was only an issue once upon a time, given that **I think** the `package-lock.json` was actually committed with **mixed line endings** within the one file at one point, if you can believe that???!?! So I don't expect it to happen here again, and yet having to commit a "normalize line endings" commit of the file itself is so annoying if it were to happen again, and creates so much noise in the `git blame`... etc. This just prevents that all from happening in the first place.)_

</details>