### PR TITLE
Fix inability to notice newer versions of git-installed packages

### DIFF
--- a/src/upgrade.coffee
+++ b/src/upgrade.coffee
@@ -116,7 +116,7 @@ class Upgrade extends Command
       git.addGitToEnv(process.env)
       @spawn command, args, {cwd: repoPath}, (code, stderr='', stdout='') ->
         return callback(new Error('Exit code: ' + code + ' - ' + stderr)) unless code is 0
-        sha = repo.getReferenceTarget(repo.getHead())
+        sha = repo.getReferenceTarget(repo.getUpstreamBranch(repo.getHead()))
         if sha isnt pack.apmInstallSource.sha
           callback(null, sha)
         else


### PR DESCRIPTION
This is a fun one. Remember #56? I thought it made it possible to update packages installed via GitHub when the package's default branch is `main` instead of `master`. Instead, I introduced a dumb mistake, the result of which was that no GitHub-installed packages _ever_ realized that their upstream had changed.

The diff makes it clear what I did wrong.

## Why didn't the tests catch this?

Because the relevant specs are written wrong — probably because it was too hard to write them correctly.

To find out if there's a new version of a package, `ppm` compares the SHA of the version it has with the SHA on the tip of the head remote branch, then upgrades the package (or shows it in a list) if the two don't match. The way the spec works is to artificially change _the SHA of the version it has_, rather than simulate retrieving the SHA from a remote whose contents have changed. 

That's what the existing spec did for the `master` branch, and that's what I did for my spec that tests the same behavior on `main`. The specs passed because they didn't ever test a situation where the local repo's head SHA differs from that of `origin`. I know what a better spec would look like, but it would mean not mocking _anything_ about retrieving information from a git remote, and I don't know how feasible that is. That's why this PR has no spec changes.

What I should've done was test this behavior with one of my own packages _before_ submitting the PR; that would've revealed that the code didn't do what I think. I hereby assert that I have done that this time around.

## To test this yourself

These steps worked for me:

1. Install any package from git (e.g., `ppm install some-git-user/some-atom-package`)
2. Go into the package's directory within Pulsar
3. Open `package.json` and copy the entire contents of the file to your clipboard, or copy the file to `package.json.bak` or something
4. Grab an old commit SHA from `git log`, then do `git reset --hard [old sha]`
5. Open up the `package.json` again and replace its _entire contents_ with your clipboard (or backup file or whatever). Then find the `apmInstallSource` field and replace the `sha` with the old SHA you just used; be sure to save
6. Run `ppm upgrade --list` and note how this package doesn't show up in the list, even though the remote head has a newer SHA
7. Reach into your live `ppm` directory within Pulsar — in my case, `/Applications/Pulsar.app/Contents/Resources/app/ppm`.
8. Open `lib/upgrade.js` (yes, the compiled version).
9. Find the line that says `sha = repo.getReferenceTarget(repo.getHead());` and replace it with `sha = repo.getReferenceTarget(repo.getUpstreamBranch(repo.getHead()));`
10. Try step 6 again; this package should appear in the upgrade list 

