### PR TITLE
Replace "apm" by "ppm" in help messages.

### DIFF
--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -29,7 +29,7 @@ module.exports =
         else
           callback """
             No package API token in keychain
-            Run `apm login` or set the `ATOM_ACCESS_TOKEN` environment variable.
+            Run `ppm login` or set the `ATOM_ACCESS_TOKEN` environment variable.
           """
 
   # Save the given token to the keychain.

--- a/src/ci.coffee
+++ b/src/ci.coffee
@@ -20,13 +20,13 @@ class Ci extends Command
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
-      Usage: apm ci
+      Usage: ppm ci
 
       Install a package with a clean slate.
 
-      If you have an up-to-date package-lock.json file created by apm install,
-      apm ci will install its locked contents exactly. It is substantially
-      faster than apm install and produces consistently reproduceable builds,
+      If you have an up-to-date package-lock.json file created by ppm install,
+      ppm ci will install its locked contents exactly. It is substantially
+      faster than ppm install and produces consistently reproduceable builds,
       but cannot be used to install new packages or dependencies.
     """
 

--- a/src/clean.coffee
+++ b/src/clean.coffee
@@ -21,7 +21,7 @@ class Clean extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
 
     options.usage """
-      Usage: apm clean
+      Usage: ppm clean
 
       Deletes all packages in the node_modules folder that are not referenced
       as a dependency in the package.json file.

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -18,11 +18,11 @@ class Config extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm config set <key> <value>
-             apm config get <key>
-             apm config delete <key>
-             apm config list
-             apm config edit
+      Usage: ppm config set <key> <value>
+             ppm config get <key>
+             ppm config delete <key>
+             ppm config list
+             ppm config edit
 
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -23,7 +23,7 @@ class Dedupe extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm dedupe [<package_name>...]
+      Usage: ppm dedupe [<package_name>...]
 
       Reduce duplication in the node_modules folder in the current directory.
 

--- a/src/develop.coffee
+++ b/src/develop.coffee
@@ -25,7 +25,7 @@ class Develop extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
 
     options.usage """
-      Usage: apm develop <package_name> [<directory>]
+      Usage: ppm develop <package_name> [<directory>]
 
       Clone the given package's Git repository to the directory specified,
       install its dependencies, and link it for development to

--- a/src/disable.coffee
+++ b/src/disable.coffee
@@ -15,7 +15,7 @@ class Disable extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm disable [<package_name>]...
+      Usage: ppm disable [<package_name>]...
 
       Disables the named package(s).
     """

--- a/src/docs.coffee
+++ b/src/docs.coffee
@@ -12,7 +12,7 @@ class Docs extends View
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm docs [options] <package_name>
+      Usage: ppm docs [options] <package_name>
 
       Open a package's homepage in the default browser.
     """

--- a/src/enable.coffee
+++ b/src/enable.coffee
@@ -14,7 +14,7 @@ class Enable extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm enable [<package_name>]...
+      Usage: ppm enable [<package_name>]...
 
       Enables the named package(s).
     """

--- a/src/featured.coffee
+++ b/src/featured.coffee
@@ -14,9 +14,9 @@ class Featured extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm featured
-             apm featured --themes
-             apm featured --compatible 0.49.0
+      Usage: ppm featured
+             ppm featured --themes
+             ppm featured --compatible 0.49.0
 
       List the Pulsar packages and themes that are currently featured.
     """
@@ -75,7 +75,7 @@ class Featured extends Command
           label
 
         console.log()
-        console.log "Use `apm install` to install them or visit #{'https://web.pulsar-edit.dev/'.underline} to read more about them."
+        console.log "Use `ppm install` to install them or visit #{'https://web.pulsar-edit.dev/'.underline} to read more about them."
         console.log()
 
       callback()

--- a/src/init.coffee
+++ b/src/init.coffee
@@ -16,18 +16,18 @@ class Init extends Command
 
     options.usage """
       Usage:
-        apm init -p <package-name>
-        apm init -p <package-name> --syntax <javascript-or-coffeescript>
-        apm init -p <package-name> -c ~/Downloads/r.tmbundle
-        apm init -p <package-name> -c https://github.com/textmate/r.tmbundle
-        apm init -p <package-name> --template /path/to/your/package/template
+        ppm init -p <package-name>
+        ppm init -p <package-name> --syntax <javascript-or-coffeescript>
+        ppm init -p <package-name> -c ~/Downloads/r.tmbundle
+        ppm init -p <package-name> -c https://github.com/textmate/r.tmbundle
+        ppm init -p <package-name> --template /path/to/your/package/template
 
-        apm init -t <theme-name>
-        apm init -t <theme-name> -c ~/Downloads/Dawn.tmTheme
-        apm init -t <theme-name> -c https://raw.github.com/chriskempson/tomorrow-theme/master/textmate/Tomorrow-Night-Eighties.tmTheme
-        apm init -t <theme-name> --template /path/to/your/theme/template
+        ppm init -t <theme-name>
+        ppm init -t <theme-name> -c ~/Downloads/Dawn.tmTheme
+        ppm init -t <theme-name> -c https://raw.github.com/chriskempson/tomorrow-theme/master/textmate/Tomorrow-Night-Eighties.tmTheme
+        ppm init -t <theme-name> --template /path/to/your/theme/template
 
-        apm init -l <language-name>
+        ppm init -l <language-name>
 
       Generates code scaffolding for either a theme or package depending
       on the option selected.
@@ -74,7 +74,7 @@ class Init extends Command
     else if options.argv.theme?
       callback('You must specify a path after the --theme argument')
     else
-      callback('You must specify either --package, --theme or --language to `apm init`')
+      callback('You must specify either --package, --theme or --language to `ppm init`')
 
   convertPackage: (sourcePath, destinationPath, callback) ->
     unless destinationPath

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -33,12 +33,12 @@ class Install extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm install [<package_name>...]
-             apm install <package_name>@<package_version>
-             apm install <git_remote> [-b <branch_or_tag_or_commit>]
-             apm install <github_username>/<github_project> [-b <branch_or_tag_or_commit>]
-             apm install --packages-file my-packages.txt
-             apm i (with any of the previous argument usage)
+      Usage: ppm install [<package_name>...]
+             ppm install <package_name>@<package_version>
+             ppm install <git_remote> [-b <branch_or_tag_or_commit>]
+             ppm install <github_username>/<github_project> [-b <branch_or_tag_or_commit>]
+             ppm install --packages-file my-packages.txt
+             ppm i (with any of the previous argument usage)
 
       Install the given Pulsar package to ~/.pulsar/packages/<package_name>.
 
@@ -144,7 +144,7 @@ class Install extends Command
 
     message += """
 
-      Run apm -v after installing Git to see what version has been detected.
+      Run ppm -v after installing Git to see what version has been detected.
     """
 
     message
@@ -597,7 +597,7 @@ class Install extends Command
           if isBundledPackage
             console.error """
               The #{name} package is bundled with Atom and should not be explicitly installed.
-              You can run `apm uninstall #{name}` to uninstall it and then the version bundled
+              You can run `ppm uninstall #{name}` to uninstall it and then the version bundled
               with Atom will be used.
             """.yellow
           @installRegisteredPackage({name, version}, options, nextInstallStep)

--- a/src/link.coffee
+++ b/src/link.coffee
@@ -15,12 +15,12 @@ class Link extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm link [<package_path>] [--name <package_name>]
+      Usage: ppm link [<package_path>] [--name <package_name>]
 
       Create a symlink for the package in ~/.pulsar/packages. The package in the
       current working directory is linked if no path is given.
 
-      Run `apm links` to view all the currently linked packages.
+      Run `ppm links` to view all the currently linked packages.
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
     options.alias('d', 'dev').boolean('dev').describe('dev', 'Link to ~/.pulsar/dev/packages')

--- a/src/links.coffee
+++ b/src/links.coffee
@@ -20,7 +20,7 @@ class Links extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm links
+      Usage: ppm links
 
       List all of the symlinked atom packages in ~/.atom/packages and
       ~/.pulsar/dev/packages.

--- a/src/list.coffee
+++ b/src/list.coffee
@@ -27,13 +27,13 @@ class List extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm list
-             apm list --themes
-             apm list --packages
-             apm list --installed
-             apm list --installed --enabled
-             apm list --installed --bare > my-packages.txt
-             apm list --json
+      Usage: ppm list
+             ppm list --themes
+             ppm list --packages
+             ppm list --installed
+             ppm list --installed --enabled
+             ppm list --installed --bare > my-packages.txt
+             ppm list --json
 
       List all the installed packages and also the packages bundled with Atom.
     """

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -22,7 +22,7 @@ class Login extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
 
     options.usage """
-      Usage: apm login
+      Usage: ppm login
 
       Enter your package API token and save it to the keychain. This token will
       be used to identify you when publishing packages.

--- a/src/publish.coffee
+++ b/src/publish.coffee
@@ -25,25 +25,25 @@ class Publish extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm publish [<newversion> | major | minor | patch | build]
-             apm publish --tag <tagname>
-             apm publish --rename <new-name>
+      Usage: ppm publish [<newversion> | major | minor | patch | build]
+             ppm publish --tag <tagname>
+             ppm publish --rename <new-name>
 
       Publish a new version of the package in the current working directory.
 
       If a new version or version increment is specified, then a new Git tag is
       created and the package.json file is updated with that new version before
-      it is published to the apm registry. The HEAD branch and the new tag are
+      it is published to the ppm registry. The HEAD branch and the new tag are
       pushed up to the remote repository automatically using this option.
 
       If a tag is provided via the --tag flag, it must have the form `vx.y.z`.
-      For example, `apm publish -t v1.12.0`.
+      For example, `ppm publish -t v1.12.0`.
 
       If a new name is provided via the --rename flag, the package.json file is
       updated with the new name and the package's name is updated.
 
-      Run `apm featured` to see all the featured packages or
-      `apm view <packagename>` to see information about your package after you
+      Run `ppm featured` to see all the featured packages or
+      `ppm view <packagename>` to see information about your package after you
       have published it.
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')

--- a/src/rebuild-module-cache.coffee
+++ b/src/rebuild-module-cache.coffee
@@ -17,7 +17,7 @@ class RebuildModuleCache extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm rebuild-module-cache
+      Usage: ppm rebuild-module-cache
 
       Rebuild the module cache for all the packages installed to
       ~/.pulsar/packages

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -22,7 +22,7 @@ class Rebuild extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm rebuild [<name> [<name> ...]]
+      Usage: ppm rebuild [<name> [<name> ...]]
 
       Rebuild the given modules currently installed in the node_modules folder
       in the current working directory.

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -15,7 +15,7 @@ class Search extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm search <package_name>
+      Usage: ppm search <package_name>
 
       Search for packages/themes.
     """
@@ -81,7 +81,7 @@ class Search extends Command
           label
 
         console.log()
-        console.log "Use `apm install` to install them or visit #{'https://web.pulsar-edit.dev'.underline} to read more about them."
+        console.log "Use `ppm install` to install them or visit #{'https://web.pulsar-edit.dev'.underline} to read more about them."
         console.log()
 
       callback()

--- a/src/star.coffee
+++ b/src/star.coffee
@@ -20,11 +20,11 @@ class Star extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm star <package_name>...
+      Usage: ppm star <package_name>...
 
       Star the given packages
 
-      Run `apm stars` to see all your starred packages.
+      Run `ppm stars` to see all your starred packages.
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
     options.boolean('installed').describe('installed', 'Star all packages in ~/.pulsar/packages')

--- a/src/stars.coffee
+++ b/src/stars.coffee
@@ -16,10 +16,10 @@ class Stars extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm stars
-             apm stars --install
-             apm stars --user thedaniel
-             apm stars --themes
+      Usage: ppm stars
+             ppm stars --install
+             ppm stars --user thedaniel
+             ppm stars --themes
 
       List or install starred Atom packages and themes.
     """
@@ -83,7 +83,7 @@ class Stars extends Command
       label
 
     console.log()
-    console.log "Use `apm stars --install` to install them all or visit #{'https://web.pulsar-edit.dev'.underline} to read more about them."
+    console.log "Use `ppm stars --install` to install them all or visit #{'https://web.pulsar-edit.dev'.underline} to read more about them."
     console.log()
     callback()
 

--- a/src/test.coffee
+++ b/src/test.coffee
@@ -15,7 +15,7 @@ class Test extends Command
 
     options.usage """
       Usage:
-        apm test
+        ppm test
 
       Runs the package's tests contained within the spec directory (relative
       to the current working directory).

--- a/src/uninstall.coffee
+++ b/src/uninstall.coffee
@@ -18,7 +18,7 @@ class Uninstall extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm uninstall <package_name>...
+      Usage: ppm uninstall <package_name>...
 
       Delete the installed package(s) from the ~/.pulsar/packages directory.
     """

--- a/src/unlink.coffee
+++ b/src/unlink.coffee
@@ -20,12 +20,12 @@ class Unlink extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm unlink [<package_path>]
+      Usage: ppm unlink [<package_path>]
 
       Delete the symlink in ~/.pulsar/packages for the package. The package in the
       current working directory is unlinked if no path is given.
 
-      Run `apm links` to view all the currently linked packages.
+      Run `ppm links` to view all the currently linked packages.
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
     options.alias('d', 'dev').boolean('dev').describe('dev', 'Unlink package from ~/.pulsar/dev/packages')

--- a/src/unpublish.coffee
+++ b/src/unpublish.coffee
@@ -17,8 +17,8 @@ class Unpublish extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
 
     options.usage """
-      Usage: apm unpublish [<package_name>]
-             apm unpublish <package_name>@<package_version>
+      Usage: ppm unpublish [<package_name>]
+             ppm unpublish <package_name>@<package_version>
 
       Remove a published package or package version.
 
@@ -68,7 +68,7 @@ class Unpublish extends Command
       question = "Are you sure you want to unpublish '#{packageLabel}'? (no) "
     else
       question = "Are you sure you want to unpublish ALL VERSIONS of '#{packageLabel}'? " +
-                 "This will remove it from the apm registry, including " +
+                 "This will remove it from the ppm registry, including " +
                  "download counts and stars, and this action is irreversible. (no)"
 
     @prompt question, (answer) =>

--- a/src/unstar.coffee
+++ b/src/unstar.coffee
@@ -14,11 +14,11 @@ class Unstar extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm unstar <package_name>...
+      Usage: ppm unstar <package_name>...
 
       Unstar the given packages
 
-      Run `apm stars` to see all your starred packages.
+      Run `ppm stars` to see all your starred packages.
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
 

--- a/src/upgrade.coffee
+++ b/src/upgrade.coffee
@@ -29,9 +29,9 @@ class Upgrade extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm upgrade
-             apm upgrade --list
-             apm upgrade [<package_name>...]
+      Usage: ppm upgrade
+             ppm upgrade --list
+             ppm upgrade [<package_name>...]
 
       Upgrade out of date packages installed to ~/.pulsar/packages
 

--- a/src/view.coffee
+++ b/src/view.coffee
@@ -15,7 +15,7 @@ class View extends Command
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """
 
-      Usage: apm view <package_name>
+      Usage: ppm view <package_name>
 
       View information about a package/theme.
     """
@@ -100,7 +100,7 @@ class View extends Command
         tree(items)
 
         console.log()
-        console.log "Run `apm install #{pack.name}` to install this package."
+        console.log "Run `ppm install #{pack.name}` to install this package."
         console.log()
 
       callback()


### PR DESCRIPTION
Replace all "apm" occurrences by "ppm" in console help messages.