### PR TITLE
Add 'ppm' bins to complement existing 'apm' bins

### DIFF
--- a/bin/ppm
+++ b/bin/ppm
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+initialCwd=`pwd -P`
+scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+apmPath=$0
+builtin cd "`dirname "$apmPath"`"
+binDir=`basename "$apmPath"`
+
+# Detect node binary name
+osName=`uname -s`
+if [ "${osName:0:10}" == 'MINGW32_NT' ]; then
+  nodeBin="node.exe"
+elif [[ $(uname -r) == *-Microsoft ]]; then
+  nodeBin="node.exe"
+else
+  nodeBin="node"
+fi
+
+while [ -L "$binDir" ]
+do
+  binDir=`readlink "$binDir"`
+  builtin cd "`dirname "$binDir"`"
+  binDir=`basename "$binDir"`
+done
+
+binDir=`pwd -P`
+
+# Force npm to use its builtin node-gyp
+unset npm_config_node_gyp
+
+cliPath="$binDir/../lib/cli.js"
+if [[ $(uname -r) == *-Microsoft ]]; then
+  cliPath="$(echo $cliPath | sed 's/\/mnt\/\([a-z]*\)\(.*\)/\1:\2/')"
+  cliPath="${cliPath////\\}"
+else
+  builtin cd "$initialCwd"
+fi
+
+"$binDir/$nodeBin" "$cliPath" "$@"

--- a/bin/ppm.cmd
+++ b/bin/ppm.cmd
@@ -1,0 +1,22 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: Try to find git.exe in path
+for /f "tokens=*" %%G in ('where git 2^>nul') do set "apm_git_path=%%~dpG"
+if not defined apm_git_path (
+  :: Try to find git.exe in GitHub Desktop, oldest first so we end with newest
+  for /f "tokens=*" %%d in ('dir /b /s /a:d /od "%LOCALAPPDATA%\GitHub\PortableGit*" 2^>nul') do (
+    if exist "%%d\cmd\git.exe" set "apm_git_path=%%d\cmd"
+  )
+  :: Found one, add it to the path
+  if defined apm_git_path set "Path=!apm_git_path!;!PATH!"
+)
+
+:: Force npm to use its builtin node-gyp
+set npm_config_node_gyp=
+
+if exist "%~dp0\node.exe" (
+  "%~dp0\node.exe" "%~dp0/../lib/cli.js" %*
+) else (
+  node.exe "%~dp0/../lib/cli.js" %*
+)

--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -16,6 +16,7 @@ if (process.platform === 'win32') {
 // so this is especially needed to allow apm to be published successfully on Windows)
 fs.chmodSync(script, 0o755)
 fs.chmodSync(path.join(__dirname, '..', 'bin', 'apm'), 0o755)
+fs.chmodSync(path.join(__dirname, '..', 'bin', 'ppm'), 0o755)
 fs.chmodSync(path.join(__dirname, '..', 'bin', 'npm'), 0o755)
 
 const child = cp.spawn(script, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true })


### PR DESCRIPTION
**I think the PR title pretty much says what's going on here, but my extended thoughts below for anyone curious**

Makes it easier to integrate ppm in various contexts, such as on the user's PATH to be run from the CLI, without having to run it as 'apm'.

**Notably, this should make it easier to get a `ppm.cmd` command on users' PATHs on Windows, based on the method we've been using so far, which ends up giving users an `apm.cmd` command on Windows...**

_Aside/commentary: It also subjectively lets us do something less "jank" feeling than for `ppm` to be a symlink to `apm` on Unix-likes (Linux + macOS)... We can do `ppm` --> `ppm` instead now... But that hasn't been an issue thus far, honestly. I don't worry myself over that one, truthfully. It's just been an itch at the back of my neck to finally do this, I suppose, and the Windows integration gave me a real reason to finally do so._

Leaving the old 'apm' and 'apm.cmd' bins in case these are useful for troubleshooting during the transition to 'ppm'-named bins, or in case some edge case requires them.

(They're two small text files, I think we can afford to keep ones with either name, at least for now, if not forever. We'll see what's best.)

And less importantly, but relatedly...

Also adjusted a script that sets the correct file permissions on Windows, although this is really only relevant for sharing the files in archives (tarballs definitely, not sure if it affects zip files) -- notably when uploading the (packed, tarballed) package to the npm registry.

_We do not publish ppm to the npm package registry_, unlike what they used to do with apm. So, this doesn't really apply to us. _Still_, I wanted there to be parity / no bit-rot in this "legacy code" in case we change our minds and start publishing ppm to the npm package registry again like they did with apm. (Or else we can delete said code, on way or the other. I vote for keeping it, since it's not doing any harm, IMO... Less churn = less unexpected issues. Low stakes, might as well keep it, again IMO).