### PR TITLE
Make `postinstall` scripts work on Windows with spaces in cwd path

### DIFF
--- a/script/bundled-node-version.js
+++ b/script/bundled-node-version.js
@@ -1,7 +1,7 @@
 const child_process = require('child_process')
 
 module.exports = function(filename, callback) {
-  child_process.exec(filename + ' -v', function(error, stdout) {
+  child_process.exec(`"${filename}" -v`, function(error, stdout) {
     if (error != null) {
       callback(error);
       return;
@@ -12,7 +12,7 @@ module.exports = function(filename, callback) {
       version = stdout.toString().trim();
     }
 
-    child_process.exec(filename + " -p 'process.arch'", function(error, stdout) {
+    child_process.exec(`"${filename}" -p 'process.arch'`, function(error, stdout) {
       let arch = null;
       if (stdout != null) {
         arch = stdout.toString().trim();

--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -19,7 +19,7 @@ fs.chmodSync(path.join(__dirname, '..', 'bin', 'apm'), 0o755)
 fs.chmodSync(path.join(__dirname, '..', 'bin', 'ppm'), 0o755)
 fs.chmodSync(path.join(__dirname, '..', 'bin', 'npm'), 0o755)
 
-const child = cp.spawn(script, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true })
+const child = cp.spawn(`"${script}"`, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true })
 child.stderr.pipe(process.stderr)
 child.stdout.pipe(process.stdout)
 child.on('close', (code) => { process.exit(code) })


### PR DESCRIPTION
Before this change, if a Windows user plans to contribute and saves PPM into a directory that has spaces in it's path, the scripts will fail. Wrapping all paths to files with `"` ensures it's handled as a string by the terminal, ensuring Windows users can contribute, without having to save this into a specific directory