### PR TITLE
Update unpublishing wording

### DIFF
--- a/src/unpublish.js
+++ b/src/unpublish.js
@@ -81,7 +81,8 @@ name is specified.\
       } else {
         question = `Are you sure you want to unpublish ALL VERSIONS of '${packageLabel}'? ` +
                    "This will remove it from the ppm registry, including " +
-                   "download counts and stars, and this action is irreversible. (no)";
+                   "download counts and stars, and will render the package " +
+                   "name permanently unusable. This action is irreversible. (no)";
       }
 
       return this.prompt(question, answer => {


### PR DESCRIPTION
Conversation thread here: https://discord.com/channels/992103415163396136/1147891572533362779/1147891572533362779

We decided it would be best to clarify the wording as it isn't clear from the text in ppm that the unpublish command will make the package name permanently unavailable.

This just adds a line to clarify that.