### PR TITLE
Skip update checks for bundled packages

### DIFF
--- a/spec/upgrade-spec.js
+++ b/spec/upgrade-spec.js
@@ -76,6 +76,23 @@ describe('apm upgrade', () => {
     });
   });
 
+  it('does not display updates for "core" packages', () => {
+    fs.writeFileSync(path.join(packagesDir, 'core-package', 'package.json'), JSON.stringify({
+      name: 'core-package',
+      version: '1.0',
+      repository: 'https://github.com/pulsar-edit/pulsar'
+    }));
+    const callback = jasmine.createSpy('callback');
+    apm.run(['upgrade', '--list', '--no-color'], callback);
+
+    waitsFor('waiting for upgrade to complete', 600000, () => callback.callCount > 0);
+
+    runs(() => {
+      expect(console.log).toHaveBeenCalled();
+      expect(console.log.argsForCall[1][0]).toContain('empty');
+    });
+  });
+
   it('does not display updates for packages whose engine does not satisfy the installed Atom version', () => {
     fs.writeFileSync(path.join(packagesDir, 'test-module', 'package.json'), JSON.stringify({
       name: 'test-module',

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -93,6 +93,12 @@ available updates.\
     }
 
     getLatestVersion(pack, callback) {
+      // We want to bail on checking for updates of any packages that come with the editor
+      // This can generally be detected by checking if the repository is that of Pulsar itself
+      if (pack.repository === "https://github.com/pulsar-edit/pulsar") {
+        return callback();
+      }
+      
       const requestSettings = {
         url: `${config.getAtomPackagesUrl()}/${pack.name}`,
         json: true


### PR DESCRIPTION
This PR allows PPM to skip checking for updates for bundled packages within Pulsar.

This only works if the package is not a valid git repository, which is true for the vast majority of our bundled packages.

Although, some outliers to this exist, those can be determined by checking the remaining items [here](https://github.com/pulsar-edit/pulsar/issues/512). As for all other of the 81 bundled packages, this should allow them to be silently skipped. Assumed to always be up to date by PPM.

This is done by checking the `repository` of the `package.json` of the package and determining if it's the same as the repository of Pulsar itself.