### PR TITLE
Update npm and node-gyp, for macOS signing fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,9 +90,9 @@
           }
         },
         "semver": {
-          "version": "7.5.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-          "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -172,37 +172,12 @@
       }
     },
     "agentkeepalive": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.3.0.tgz",
-      "integrity": "sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.0",
-        "depd": "^2.0.0",
         "humanize-ms": "^1.2.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "aggregate-error": {
@@ -485,16 +460,16 @@
       "dev": true
     },
     "cacache": {
-      "version": "17.1.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.3.tgz",
-      "integrity": "sha512-jAdjGxmPxZh0IipMdR7fK/4sDSrHMLUV0+GvVUsjwyGNKHsh79kW/otg+GkbXwl6Uzvy9wsvHOX4nUoWldeZMg==",
+      "version": "17.1.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.4.tgz",
+      "integrity": "sha512-/aJwG2l3ZMJ1xNAnqbMpA40of9dj/pIH3QfiuQSqjfPJF747VR0J/bHn+/KdNnHKc6XQcWt/AfRSBft82W1d2A==",
       "dev": true,
       "requires": {
         "@npmcli/fs": "^3.1.0",
         "fs-minipass": "^3.0.0",
         "glob": "^10.2.2",
         "lru-cache": "^7.7.1",
-        "minipass": "^5.0.0",
+        "minipass": "^7.0.3",
         "minipass-collect": "^1.0.2",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
@@ -520,16 +495,16 @@
           "dev": true
         },
         "glob": {
-          "version": "10.2.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.7.tgz",
-          "integrity": "sha512-jTKehsravOJo8IJxUGfZILnkvVJM/MOfHRs8QcXolVef2zNI9Tqyy5+SeuOAZd3upViEZQLyFpQhYiHLrMUNmA==",
+          "version": "10.3.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
+          "integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
           "dev": true,
           "requires": {
             "foreground-child": "^3.1.0",
             "jackspeak": "^2.0.3",
             "minimatch": "^9.0.1",
-            "minipass": "^5.0.0 || ^6.0.2",
-            "path-scurry": "^1.7.0"
+            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+            "path-scurry": "^1.10.1"
           }
         },
         "lru-cache": {
@@ -539,13 +514,19 @@
           "dev": true
         },
         "minimatch": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-          "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
+        },
+        "minipass": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+          "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+          "dev": true
         },
         "mkdirp": {
           "version": "1.0.4",
@@ -554,9 +535,9 @@
           "dev": true
         },
         "tar": {
-          "version": "6.1.15",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
-          "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
+          "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
           "dev": true,
           "requires": {
             "chownr": "^2.0.0",
@@ -586,6 +567,12 @@
                   }
                 }
               }
+            },
+            "minipass": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+              "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+              "dev": true
             }
           }
         }
@@ -764,12 +751,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true
-    },
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -839,6 +820,17 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "cson-parser": {
@@ -1262,20 +1254,6 @@
         "unpipe": "~1.0.0"
       }
     },
-    "first-mate": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-7.4.3.tgz",
-      "integrity": "sha512-PtZUpaPmcV5KV4Rw5TfwczEnExN+X1o3Q/G82E4iRJ0tW91fm3Yi7pa5t4cBH8r3D6EyoBKvfpG2jKE+TZ0/nw==",
-      "requires": {
-        "emissary": "^1",
-        "event-kit": "^2.2.0",
-        "fs-plus": "^3.0.0",
-        "grim": "^2.0.1",
-        "oniguruma": "^7.2.3",
-        "season": "^6.0.2",
-        "underscore-plus": "^1"
-      }
-    },
     "foreground-child": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -1287,9 +1265,9 @@
       },
       "dependencies": {
         "signal-exit": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-          "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
           "dev": true
         }
       }
@@ -1349,12 +1327,20 @@
       }
     },
     "fs-minipass": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.2.tgz",
-      "integrity": "sha512-2GAfyfoaCDRrM6jaOS3UsBts8yJ55VioXdWcOL7dK9zdAuKT71+WBA4ifnNYqVjYv+4SsPxjK0JT4yIIn4cA/g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
       "dev": true,
       "requires": {
-        "minipass": "^5.0.0"
+        "minipass": "^7.0.3"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+          "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+          "dev": true
+        }
       }
     },
     "fs-plus": {
@@ -1750,9 +1736,9 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jackspeak": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.1.tgz",
-      "integrity": "sha512-MXbxovZ/Pm42f6cDIDkl3xpwv1AGwObKwfmjs2nQePiy85tP3fatofl3FC1aBsOtP/6fq5SbtgHwWcMsLP+bDw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.3.tgz",
+      "integrity": "sha512-R2bUw+kVZFS/h1AZqBKrSgDmdmjApzgY0AlCPumopFiAlbUxE2gf+SCuBzQ0cP5hHmUmFYF5yw55T97Th5Kstg==",
       "dev": true,
       "requires": {
         "@isaacs/cliui": "^8.0.2",
@@ -1992,15 +1978,23 @@
       }
     },
     "minipass-fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.3.tgz",
-      "integrity": "sha512-n5ITsTkDqYkYJZjcRWzZt9qnZKCT7nKCosJhHoj7S7zD+BP4jVbWs+odsniw5TA3E0sLomhTKOKjF86wf11PuQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.4.tgz",
+      "integrity": "sha512-jHAqnA728uUpIaFm7NWsCnqKT6UqZz7GcI/bDpPATuwYyKwJwW0remxSCxUlKiEty+eopHGa3oc8WxgQ1FFJqg==",
       "dev": true,
       "requires": {
         "encoding": "^0.1.13",
-        "minipass": "^5.0.0",
+        "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
         "minizlib": "^2.1.2"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+          "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+          "dev": true
+        }
       }
     },
     "minipass-flush": {
@@ -2205,50 +2199,41 @@
       "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
     },
     "node-gyp": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.0.tgz",
-      "integrity": "sha512-dMXsYP6gc9rRbejLXmTbVRYjAHw7ppswsKyMxuxJxxOHzluIO1rGp9TOQgjFJ+2MCqcOcQTOPB/8Xwhr+7s4Eg==",
+      "version": "https://github.com/nodejs/node-gyp/archive/d3615c66f7e7a65de48ce9860b1fe13710d20988.tar.gz",
+      "integrity": "sha512-ANl8mRexkANG+Q07tdTW6WYTp28OHpE8eT9qcMJmsXbI3pPoasIqJ86XqhQdu7+tF6LRlHLEhLBjdYAUp2Pp9w==",
       "dev": true,
       "requires": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
-        "glob": "^7.1.4",
+        "glob": "^8.0.3",
         "graceful-fs": "^4.2.6",
         "make-fetch-happen": "^11.0.3",
-        "nopt": "^6.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
+        "nopt": "^7.0.0",
+        "proc-log": "^3.0.0",
         "semver": "^7.3.5",
         "tar": "^6.1.2",
-        "which": "^2.0.2"
+        "which": "^3.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+        "abbrev": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+          "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
           "dev": true
         },
-        "are-we-there-yet": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-          "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^3.6.0"
+            "balanced-match": "^1.0.0"
           }
         },
         "chownr": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
           "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "dev": true
         },
         "fs-minipass": {
@@ -2271,32 +2256,23 @@
             }
           }
         },
-        "gauge": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-          "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
           "dev": true,
           "requires": {
-            "aproba": "^1.0.3 || ^2.0.0",
-            "color-support": "^1.1.3",
-            "console-control-strings": "^1.1.0",
-            "has-unicode": "^2.0.1",
-            "signal-exit": "^3.0.7",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "wide-align": "^1.1.5"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
           }
         },
         "graceful-fs": {
           "version": "4.2.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
           "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "lru-cache": {
@@ -2308,6 +2284,15 @@
             "yallist": "^4.0.0"
           }
         },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -2315,91 +2300,27 @@
           "dev": true
         },
         "nopt": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
-          "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.0.tgz",
+          "integrity": "sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==",
           "dev": true,
           "requires": {
-            "abbrev": "^1.0.0"
+            "abbrev": "^2.0.0"
           }
-        },
-        "npmlog": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-          "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-          "dev": true,
-          "requires": {
-            "are-we-there-yet": "^3.0.0",
-            "console-control-strings": "^1.1.0",
-            "gauge": "^4.0.3",
-            "set-blocking": "^2.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
         },
         "semver": {
-          "version": "7.5.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-          "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
-        "signal-exit": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-          "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
         "tar": {
-          "version": "6.1.15",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
-          "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
+          "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
           "dev": true,
           "requires": {
             "chownr": "^2.0.0",
@@ -2408,15 +2329,6 @@
             "minizlib": "^2.1.1",
             "mkdirp": "^1.0.3",
             "yallist": "^4.0.0"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-          "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2 || 3 || 4"
           }
         }
       }
@@ -2435,8 +2347,8 @@
       }
     },
     "npm": {
-      "version": "https://github.com/pulsar-edit/npm-cli/releases/download/v6.14.19-pulsar/npm-6.14.19-pulsar.tgz",
-      "integrity": "sha512-z9C1+boyOmKOTn0SzUnrOr7wXqqF2N5cKGE5CRN2FcokfKwLfXmg7sleFWYRytembCoOX9ipL0xR4t5+gPVnSA==",
+      "version": "https://github.com/pulsar-edit/npm-cli/releases/download/v6.14.19-pulsar1-1/npm-6.14.19-pulsar1-1.tgz",
+      "integrity": "sha512-axUW00G6k2vV/G+Y8xRGkCNKOcP7BoizkqjNvZvWKMmP5R9fGXT8U5ZJiOoCYSH77m8TcedyJ01f5KOwhAcS5w==",
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -2480,8 +2392,8 @@
         "is-cidr": "^3.1.1",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "https://github.com/pulsar-edit/libcipm/releases/download/v4.0.9-pulsar/libcipm-4.0.9-pulsar.tgz",
-        "libnpm": "https://github.com/pulsar-edit/libnpm/releases/download/v3.0.2-pulsar/libnpm-3.0.2-pulsar.tgz",
+        "libcipm": "https://github.com/pulsar-edit/libcipm/archive/39984e5996e5dd14773e3433cc9d8c28fcf2aafa.tar.gz",
+        "libnpm": "https://github.com/pulsar-edit/libnpm/archive/214ce1e19008636e9637ff461d24f221dbe74a09.tar.gz",
         "libnpmaccess": "^3.0.2",
         "libnpmhook": "^5.0.3",
         "libnpmorg": "^1.0.1",
@@ -2506,13 +2418,13 @@
         "mississippi": "^3.0.0",
         "mkdirp": "^0.5.6",
         "move-concurrently": "^1.0.1",
-        "node-gyp": "^9.4.0",
+        "node-gyp": "https://github.com/nodejs/node-gyp/archive/d3615c66f7e7a65de48ce9860b1fe13710d20988.tar.gz",
         "nopt": "^4.0.3",
         "normalize-package-data": "^2.5.0",
         "npm-audit-report": "^1.3.3",
         "npm-cache-filename": "~1.0.2",
         "npm-install-checks": "^3.0.2",
-        "npm-lifecycle": "https://github.com/pulsar-edit/npm-lifecycle/releases/download/v3.1.6-pulsar/npm-lifecycle-3.1.6-pulsar.tgz",
+        "npm-lifecycle": "https://github.com/pulsar-edit/npm-lifecycle/archive/7d7d20ffbb596602c2ef6caaad9356413aa586ba.tar.gz",
         "npm-package-arg": "^6.1.1",
         "npm-packlist": "^1.4.8",
         "npm-pick-manifest": "^3.0.2",
@@ -3072,11 +2984,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
-        "color-support": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-          "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
-        },
         "colors": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
@@ -3323,11 +3230,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
         },
         "detect-indent": {
           "version": "5.0.0",
@@ -4299,8 +4201,8 @@
           "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc="
         },
         "libcipm": {
-          "version": "https://github.com/pulsar-edit/libcipm/releases/download/v4.0.9-pulsar/libcipm-4.0.9-pulsar.tgz",
-          "integrity": "sha512-SdiiRIRSGvPdNUkxjM2sPG7XPnl7wAxOiw1NhJ897dOpnLbv5pMMtuksyA9Wd2vg+XXn6Vli4LKNH/EdUJ3TWg==",
+          "version": "https://github.com/pulsar-edit/libcipm/archive/39984e5996e5dd14773e3433cc9d8c28fcf2aafa.tar.gz",
+          "integrity": "sha512-geda4hHEOUfdcx9C6Qpilu8fVSGY1VeJObczIgpFbkqUG4thUqXOtKOV86G0OHCdEQdzCOcSGQZwq4TS5vqlUA==",
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.1",
@@ -4310,7 +4212,7 @@
             "ini": "^1.3.5",
             "lock-verify": "^2.1.0",
             "mkdirp": "^0.5.1",
-            "npm-lifecycle": "https://github.com/pulsar-edit/npm-lifecycle/releases/download/v3.1.6-pulsar/npm-lifecycle-3.1.6-pulsar.tgz",
+            "npm-lifecycle": "https://github.com/pulsar-edit/npm-lifecycle/archive/7d7d20ffbb596602c2ef6caaad9356413aa586ba.tar.gz",
             "npm-logical-tree": "^1.2.1",
             "npm-package-arg": "^6.1.0",
             "pacote": "^9.1.0",
@@ -4320,8 +4222,8 @@
           }
         },
         "libnpm": {
-          "version": "https://github.com/pulsar-edit/libnpm/releases/download/v3.0.2-pulsar/libnpm-3.0.2-pulsar.tgz",
-          "integrity": "sha512-LBMnSwQYKsld0FxoxvwSHJnDRNTaNnhwilf6Lksz+Z4CkrthAkejTIfIpxisxy9riY6qo9Cytkyz5T9n9zmi0Q==",
+          "version": "https://github.com/pulsar-edit/libnpm/archive/214ce1e19008636e9637ff461d24f221dbe74a09.tar.gz",
+          "integrity": "sha512-jLxHuA+Jmd2pu/SMY5cakVNlC4XRz1OaJsu4LT0l/+cdFR/Vt0gJPuqKh+x4PIsuY/VgxfZc/j6Ouv1rDC3ISA==",
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.3",
@@ -4334,7 +4236,7 @@
             "libnpmsearch": "^2.0.2",
             "libnpmteam": "^1.0.2",
             "lock-verify": "^2.0.2",
-            "npm-lifecycle": "https://github.com/pulsar-edit/npm-lifecycle/releases/download/v3.1.6-pulsar/npm-lifecycle-3.1.6-pulsar.tgz",
+            "npm-lifecycle": "https://github.com/pulsar-edit/npm-lifecycle/archive/7d7d20ffbb596602c2ef6caaad9356413aa586ba.tar.gz",
             "npm-logical-tree": "^1.2.1",
             "npm-package-arg": "^6.1.0",
             "npm-profile": "^4.0.2",
@@ -4898,27 +4800,30 @@
           }
         },
         "node-gyp": {
-          "version": "9.4.0",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.0.tgz",
-          "integrity": "sha512-dMXsYP6gc9rRbejLXmTbVRYjAHw7ppswsKyMxuxJxxOHzluIO1rGp9TOQgjFJ+2MCqcOcQTOPB/8Xwhr+7s4Eg==",
+          "version": "https://github.com/nodejs/node-gyp/archive/d3615c66f7e7a65de48ce9860b1fe13710d20988.tar.gz",
+          "integrity": "sha512-ANl8mRexkANG+Q07tdTW6WYTp28OHpE8eT9qcMJmsXbI3pPoasIqJ86XqhQdu7+tF6LRlHLEhLBjdYAUp2Pp9w==",
           "requires": {
             "env-paths": "^2.2.0",
             "exponential-backoff": "^3.1.1",
-            "glob": "^7.1.4",
+            "glob": "^8.0.3",
             "graceful-fs": "^4.2.6",
             "make-fetch-happen": "^11.0.3",
-            "nopt": "^6.0.0",
-            "npmlog": "^6.0.0",
-            "rimraf": "^3.0.2",
+            "nopt": "^7.0.0",
+            "proc-log": "^3.0.0",
             "semver": "^7.3.5",
             "tar": "^6.1.2",
-            "which": "^2.0.2"
+            "which": "^3.0.0"
           },
           "dependencies": {
             "@tootallnate/once": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
               "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+            },
+            "abbrev": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+              "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="
             },
             "agent-base": {
               "version": "6.0.2",
@@ -4929,27 +4834,11 @@
               }
             },
             "agentkeepalive": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.3.0.tgz",
-              "integrity": "sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==",
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+              "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
               "requires": {
-                "debug": "^4.1.0",
-                "depd": "^2.0.0",
                 "humanize-ms": "^1.2.1"
-              }
-            },
-            "ansi-regex": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-            },
-            "are-we-there-yet": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-              "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
               }
             },
             "brace-expansion": {
@@ -4961,15 +4850,15 @@
               }
             },
             "cacache": {
-              "version": "17.1.3",
-              "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.3.tgz",
-              "integrity": "sha512-jAdjGxmPxZh0IipMdR7fK/4sDSrHMLUV0+GvVUsjwyGNKHsh79kW/otg+GkbXwl6Uzvy9wsvHOX4nUoWldeZMg==",
+              "version": "17.1.4",
+              "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.4.tgz",
+              "integrity": "sha512-/aJwG2l3ZMJ1xNAnqbMpA40of9dj/pIH3QfiuQSqjfPJF747VR0J/bHn+/KdNnHKc6XQcWt/AfRSBft82W1d2A==",
               "requires": {
                 "@npmcli/fs": "^3.1.0",
                 "fs-minipass": "^3.0.0",
                 "glob": "^10.2.2",
                 "lru-cache": "^7.7.1",
-                "minipass": "^5.0.0",
+                "minipass": "^7.0.3",
                 "minipass-collect": "^1.0.2",
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
@@ -4980,16 +4869,29 @@
               },
               "dependencies": {
                 "glob": {
-                  "version": "10.2.7",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.7.tgz",
-                  "integrity": "sha512-jTKehsravOJo8IJxUGfZILnkvVJM/MOfHRs8QcXolVef2zNI9Tqyy5+SeuOAZd3upViEZQLyFpQhYiHLrMUNmA==",
+                  "version": "10.3.4",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
+                  "integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
                   "requires": {
                     "foreground-child": "^3.1.0",
                     "jackspeak": "^2.0.3",
                     "minimatch": "^9.0.1",
-                    "minipass": "^5.0.0 || ^6.0.2",
-                    "path-scurry": "^1.7.0"
+                    "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+                    "path-scurry": "^1.10.1"
                   }
+                },
+                "minimatch": {
+                  "version": "9.0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+                  "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+                  "requires": {
+                    "brace-expansion": "^2.0.1"
+                  }
+                },
+                "minipass": {
+                  "version": "7.0.3",
+                  "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+                  "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg=="
                 }
               }
             },
@@ -5006,6 +4908,16 @@
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
+              },
+              "dependencies": {
+                "which": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                  "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                  "requires": {
+                    "isexe": "^2.0.0"
+                  }
+                }
               }
             },
             "debug": {
@@ -5015,11 +4927,6 @@
               "requires": {
                 "ms": "2.1.2"
               }
-            },
-            "emoji-regex": {
-              "version": "8.0.0",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
             },
             "err-code": {
               "version": "2.0.3",
@@ -5036,33 +4943,30 @@
               }
             },
             "fs-minipass": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.2.tgz",
-              "integrity": "sha512-2GAfyfoaCDRrM6jaOS3UsBts8yJ55VioXdWcOL7dK9zdAuKT71+WBA4ifnNYqVjYv+4SsPxjK0JT4yIIn4cA/g==",
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+              "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
               "requires": {
-                "minipass": "^5.0.0"
-              }
-            },
-            "gauge": {
-              "version": "4.0.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-              "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-              "requires": {
-                "aproba": "^1.0.3 || ^2.0.0",
-                "color-support": "^1.1.3",
-                "console-control-strings": "^1.1.0",
-                "has-unicode": "^2.0.1",
-                "signal-exit": "^3.0.7",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1",
-                "wide-align": "^1.1.5"
+                "minipass": "^7.0.3"
               },
               "dependencies": {
-                "signal-exit": {
-                  "version": "3.0.7",
-                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-                  "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+                "minipass": {
+                  "version": "7.0.3",
+                  "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+                  "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg=="
                 }
+              }
+            },
+            "glob": {
+              "version": "8.1.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+              "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
               }
             },
             "http-cache-semantics": {
@@ -5094,11 +4998,6 @@
               "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
               "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
             },
-            "is-fullwidth-code-point": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-              "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-            },
             "lru-cache": {
               "version": "7.18.3",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -5127,9 +5026,9 @@
               }
             },
             "minimatch": {
-              "version": "9.0.1",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-              "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+              "version": "5.1.6",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+              "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
               "requires": {
                 "brace-expansion": "^2.0.1"
               }
@@ -5169,22 +5068,11 @@
               "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
             },
             "nopt": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
-              "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.0.tgz",
+              "integrity": "sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==",
               "requires": {
-                "abbrev": "^1.0.0"
-              }
-            },
-            "npmlog": {
-              "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-              "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-              "requires": {
-                "are-we-there-yet": "^3.0.0",
-                "console-control-strings": "^1.1.0",
-                "gauge": "^4.0.3",
-                "set-blocking": "^2.0.0"
+                "abbrev": "^2.0.0"
               }
             },
             "path-key": {
@@ -5201,18 +5089,10 @@
                 "retry": "^0.12.0"
               }
             },
-            "rimraf": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-              "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
             "semver": {
-              "version": "7.5.2",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-              "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+              "version": "7.5.4",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+              "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
               "requires": {
                 "lru-cache": "^6.0.0"
               },
@@ -5241,9 +5121,9 @@
               "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
             },
             "signal-exit": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-              "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q=="
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+              "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
             },
             "smart-buffer": {
               "version": "4.2.0",
@@ -5270,35 +5150,24 @@
               }
             },
             "ssri": {
-              "version": "10.0.4",
-              "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.4.tgz",
-              "integrity": "sha512-12+IR2CB2C28MMAw0Ncqwj5QbTcs0nGIhgJzYWzDkb21vWmfNI83KS4f3Ci6GI98WreIfG7o9UXp3C0qbpA8nQ==",
+              "version": "10.0.5",
+              "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.5.tgz",
+              "integrity": "sha512-bSf16tAFkGeRlUNDjXu8FzaMQt6g2HZJrun7mtMbIPOddxt3GLMSz5VWUWcqTJUPfLEaDIepGxv+bYQW49596A==",
               "requires": {
-                "minipass": "^5.0.0"
-              }
-            },
-            "string-width": {
-              "version": "4.2.3",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-              "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-              "requires": {
-                "ansi-regex": "^5.0.1"
+                "minipass": "^7.0.3"
+              },
+              "dependencies": {
+                "minipass": {
+                  "version": "7.0.3",
+                  "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+                  "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg=="
+                }
               }
             },
             "tar": {
-              "version": "6.1.15",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
-              "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
+              "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
               "requires": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
@@ -5345,19 +5214,11 @@
               }
             },
             "which": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-              "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+              "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
               "requires": {
                 "isexe": "^2.0.0"
-              }
-            },
-            "wide-align": {
-              "version": "1.1.5",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-              "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-              "requires": {
-                "string-width": "^1.0.2 || 2 || 3 || 4"
               }
             },
             "yallist": {
@@ -5428,12 +5289,12 @@
           }
         },
         "npm-lifecycle": {
-          "version": "https://github.com/pulsar-edit/npm-lifecycle/releases/download/v3.1.6-pulsar/npm-lifecycle-3.1.6-pulsar.tgz",
-          "integrity": "sha512-l760UYIIS6EVnONlQFgdg780YWRiaGs5b4uPHzJ+cujJ3hYVmDvIziCEG70pKRZYRGuvbFyog/ilodp/8LPPQg==",
+          "version": "https://github.com/pulsar-edit/npm-lifecycle/archive/7d7d20ffbb596602c2ef6caaad9356413aa586ba.tar.gz",
+          "integrity": "sha512-lyy2EF87WVU3sRcKnwr9yUmaESY+68LtiVsdGtEMNtkAgGEbk7kgxcvhtFoOpzKgWg3pgdJG+NJc7JLQvaPhWA==",
           "requires": {
             "byline": "^5.0.0",
             "graceful-fs": "^4.1.15",
-            "node-gyp": "^9.4.0",
+            "node-gyp": "https://github.com/nodejs/node-gyp/archive/d3615c66f7e7a65de48ce9860b1fe13710d20988.tar.gz",
             "resolve-from": "^4.0.0",
             "slide": "^1.1.6",
             "uid-number": "0.0.6",
@@ -5744,23 +5605,23 @@
           "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
         "path-scurry": {
-          "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
-          "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+          "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
           "requires": {
-            "lru-cache": "^9.1.1",
-            "minipass": "^5.0.0 || ^6.0.2"
+            "lru-cache": "^9.1.1 || ^10.0.0",
+            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
           },
           "dependencies": {
             "lru-cache": {
-              "version": "9.1.2",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
-              "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ=="
+              "version": "10.0.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+              "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g=="
             },
             "minipass": {
-              "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-              "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w=="
+              "version": "7.0.3",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+              "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg=="
             }
           }
         },
@@ -5778,6 +5639,11 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
           "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+        },
+        "proc-log": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
+          "integrity": "sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A=="
         },
         "process-nextick-args": {
           "version": "2.0.0",
@@ -6960,14 +6826,6 @@
         "wrappy": "1"
       }
     },
-    "oniguruma": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-7.2.3.tgz",
-      "integrity": "sha512-PZZcE0yfg8Q1IvaJImh21RUTHl8ep0zwwyoE912KqlWVrsGByjjj29sdACcD1BFyX2bLkfuOJeP+POzAGVWtbA==",
-      "requires": {
-        "nan": "^2.14.0"
-      }
-    },
     "open": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/open/-/open-7.3.0.tgz",
@@ -7041,19 +6899,19 @@
       "dev": true
     },
     "path-scurry": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
-      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "^9.1.1",
-        "minipass": "^5.0.0 || ^6.0.2"
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "9.1.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
-          "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
           "dev": true
         }
       }
@@ -7096,6 +6954,12 @@
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
+    },
+    "proc-log": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
+      "integrity": "sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -7308,6 +7172,19 @@
         }
       }
     },
+    "second-mate": {
+      "version": "git+https://github.com/pulsar-edit/second-mate.git#9686771b4aa3159fe042528d60fcac3af3e1c655",
+      "from": "git+https://github.com/pulsar-edit/second-mate.git#9686771",
+      "requires": {
+        "emissary": "^1.3.3",
+        "event-kit": "^2.5.3",
+        "fs-plus": "^3.0.0",
+        "grim": "^2.0.3",
+        "season": "^6.0.2",
+        "underscore-plus": "^1",
+        "vscode-oniguruma": "^1.7.0"
+      }
+    },
     "semver": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
@@ -7518,12 +7395,20 @@
       }
     },
     "ssri": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.4.tgz",
-      "integrity": "sha512-12+IR2CB2C28MMAw0Ncqwj5QbTcs0nGIhgJzYWzDkb21vWmfNI83KS4f3Ci6GI98WreIfG7o9UXp3C0qbpA8nQ==",
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.5.tgz",
+      "integrity": "sha512-bSf16tAFkGeRlUNDjXu8FzaMQt6g2HZJrun7mtMbIPOddxt3GLMSz5VWUWcqTJUPfLEaDIepGxv+bYQW49596A==",
       "dev": true,
       "requires": {
-        "minipass": "^5.0.0"
+        "minipass": "^7.0.3"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+          "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+          "dev": true
+        }
       }
     },
     "statuses": {
@@ -7886,6 +7771,11 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+    },
     "walkdir": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.7.tgz",
@@ -7893,9 +7783,9 @@
       "dev": true
     },
     "which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "keytar": "^7.7.0",
     "mv": "2.1.1",
     "ncp": "~2.0.0",
-    "npm": "https://github.com/pulsar-edit/npm-cli/releases/download/v6.14.19-pulsar/npm-6.14.19-pulsar.tgz",
+    "npm": "https://github.com/pulsar-edit/npm-cli/releases/download/v6.14.19-pulsar1-1/npm-6.14.19-pulsar1-1.tgz",
     "open": "7.3.0",
     "q": "~1.5.1",
     "read": "~1.0.7",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "coffeelint": "<2.0",
     "express": "^4.17.1",
     "jasmine-focused": ">=1.0.7 <2.0",
-    "node-gyp": "^9.4.0",
+    "node-gyp": "https://github.com/nodejs/node-gyp/archive/d3615c66f7e7a65de48ce9860b1fe13710d20988.tar.gz",
     "shx": "^0.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,7 +69,7 @@ JSONStream@^1.3.4, JSONStream@^1.3.5:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-abbrev@1, abbrev@^1.0.0, abbrev@~1.1.1:
+abbrev@1, abbrev@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
@@ -213,7 +213,7 @@ aproba@^1.0.3, aproba@^1.1.1, aproba@^1.1.2:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
-"aproba@^1.0.3 || ^2.0.0", "aproba@^1.1.2 || 2", aproba@^2.0.0:
+"aproba@^1.1.2 || 2", aproba@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
@@ -222,14 +222,6 @@ archy@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==
-
-are-we-there-yet@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz#679df222b278c64f2cdba1175cdc00b0d96164bd"
-  integrity sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^3.6.0"
 
 are-we-there-yet@~1.1.2:
   version "1.1.7"
@@ -703,11 +695,6 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-color-support@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
-  integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
 colors@^1.1.2, colors@~1.4.0:
   version "1.4.0"
@@ -1554,20 +1541,6 @@ functions-have-names@^1.2.2:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
-gauge@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-4.0.4.tgz#52ff0652f2bbf607a989793d53b751bef2328dce"
-  integrity sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==
-  dependencies:
-    aproba "^1.0.3 || ^2.0.0"
-    color-support "^1.1.3"
-    console-control-strings "^1.1.0"
-    has-unicode "^2.0.1"
-    signal-exit "^3.0.7"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
-    wide-align "^1.1.5"
-
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -1807,7 +1780,7 @@ has-tostringtag@^1.0.0:
   dependencies:
     has-symbols "^1.0.2"
 
-has-unicode@^2.0.0, has-unicode@^2.0.1, has-unicode@~2.0.1:
+has-unicode@^2.0.0, has-unicode@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
@@ -2358,9 +2331,9 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-"libcipm@https://github.com/pulsar-edit/libcipm/releases/download/v4.0.9-pulsar/libcipm-4.0.9-pulsar.tgz":
-  version "4.0.9-pulsar"
-  resolved "https://github.com/pulsar-edit/libcipm/releases/download/v4.0.9-pulsar/libcipm-4.0.9-pulsar.tgz#efa0592ab721915b5d40ec5892435f751b3bd55e"
+"libcipm@https://github.com/pulsar-edit/libcipm/archive/39984e5996e5dd14773e3433cc9d8c28fcf2aafa.tar.gz":
+  version "4.0.9-pulsar1"
+  resolved "https://github.com/pulsar-edit/libcipm/archive/39984e5996e5dd14773e3433cc9d8c28fcf2aafa.tar.gz#8e8fdaef98d90bf5911e50bd7b685f4cdd7c09aa"
   dependencies:
     bin-links "^1.1.2"
     bluebird "^3.5.1"
@@ -2370,7 +2343,7 @@ lcid@^1.0.0:
     ini "^1.3.5"
     lock-verify "^2.1.0"
     mkdirp "^0.5.1"
-    npm-lifecycle "https://github.com/pulsar-edit/npm-lifecycle/releases/download/v3.1.6-pulsar/npm-lifecycle-3.1.6-pulsar.tgz"
+    npm-lifecycle "https://github.com/pulsar-edit/npm-lifecycle/archive/7d7d20ffbb596602c2ef6caaad9356413aa586ba.tar.gz"
     npm-logical-tree "^1.2.1"
     npm-package-arg "^6.1.0"
     pacote "^9.1.0"
@@ -2378,9 +2351,9 @@ lcid@^1.0.0:
     rimraf "^2.6.2"
     worker-farm "^1.6.0"
 
-"libnpm@https://github.com/pulsar-edit/libnpm/releases/download/v3.0.2-pulsar/libnpm-3.0.2-pulsar.tgz":
-  version "3.0.2-pulsar"
-  resolved "https://github.com/pulsar-edit/libnpm/releases/download/v3.0.2-pulsar/libnpm-3.0.2-pulsar.tgz#d79ed5662daf43d79dc8664358656a325294af4a"
+"libnpm@https://github.com/pulsar-edit/libnpm/archive/214ce1e19008636e9637ff461d24f221dbe74a09.tar.gz":
+  version "3.0.2-pulsar1"
+  resolved "https://github.com/pulsar-edit/libnpm/archive/214ce1e19008636e9637ff461d24f221dbe74a09.tar.gz#35f879e16dcc7b7f51e46550bffda90ac3c0eb8a"
   dependencies:
     bin-links "^1.1.2"
     bluebird "^3.5.3"
@@ -2393,7 +2366,7 @@ lcid@^1.0.0:
     libnpmsearch "^2.0.2"
     libnpmteam "^1.0.2"
     lock-verify "^2.0.2"
-    npm-lifecycle "https://github.com/pulsar-edit/npm-lifecycle/releases/download/v3.1.6-pulsar/npm-lifecycle-3.1.6-pulsar.tgz"
+    npm-lifecycle "https://github.com/pulsar-edit/npm-lifecycle/archive/7d7d20ffbb596602c2ef6caaad9356413aa586ba.tar.gz"
     npm-logical-tree "^1.2.1"
     npm-package-arg "^6.1.0"
     npm-profile "^4.0.2"
@@ -2998,23 +2971,6 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-gyp@^9.4.0:
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-9.4.0.tgz#2a7a91c7cba4eccfd95e949369f27c9ba704f369"
-  integrity sha512-dMXsYP6gc9rRbejLXmTbVRYjAHw7ppswsKyMxuxJxxOHzluIO1rGp9TOQgjFJ+2MCqcOcQTOPB/8Xwhr+7s4Eg==
-  dependencies:
-    env-paths "^2.2.0"
-    exponential-backoff "^3.1.1"
-    glob "^7.1.4"
-    graceful-fs "^4.2.6"
-    make-fetch-happen "^11.0.3"
-    nopt "^6.0.0"
-    npmlog "^6.0.0"
-    rimraf "^3.0.2"
-    semver "^7.3.5"
-    tar "^6.1.2"
-    which "^2.0.2"
-
 "node-gyp@https://github.com/nodejs/node-gyp/archive/d3615c66f7e7a65de48ce9860b1fe13710d20988.tar.gz":
   version "9.4.0"
   uid "42925551931cf5b511c0755b1ad1c5aa876d36d3"
@@ -3045,13 +3001,6 @@ nopt@^4.0.3:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
-
-nopt@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-6.0.0.tgz#245801d8ebf409c6df22ab9d95b65e1309cdb16d"
-  integrity sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==
-  dependencies:
-    abbrev "^1.0.0"
 
 nopt@^7.0.0:
   version "7.2.0"
@@ -3104,13 +3053,14 @@ npm-install-checks@^3.0.2:
   dependencies:
     semver "^2.3.0 || 3.x || 4 || 5"
 
-"npm-lifecycle@https://github.com/pulsar-edit/npm-lifecycle/releases/download/v3.1.6-pulsar/npm-lifecycle-3.1.6-pulsar.tgz":
-  version "3.1.6-pulsar"
-  resolved "https://github.com/pulsar-edit/npm-lifecycle/releases/download/v3.1.6-pulsar/npm-lifecycle-3.1.6-pulsar.tgz#af5e4b440656daeed01e10861460664c14b30d7b"
+"npm-lifecycle@https://github.com/pulsar-edit/npm-lifecycle/archive/7d7d20ffbb596602c2ef6caaad9356413aa586ba.tar.gz":
+  version "3.1.6-pulsar1"
+  uid a0162e7a6019a62c2c257249018cbbf0f3a342de
+  resolved "https://github.com/pulsar-edit/npm-lifecycle/archive/7d7d20ffbb596602c2ef6caaad9356413aa586ba.tar.gz#a0162e7a6019a62c2c257249018cbbf0f3a342de"
   dependencies:
     byline "^5.0.0"
     graceful-fs "^4.1.15"
-    node-gyp "^9.4.0"
+    node-gyp "https://github.com/nodejs/node-gyp/archive/d3615c66f7e7a65de48ce9860b1fe13710d20988.tar.gz"
     resolve-from "^4.0.0"
     slide "^1.1.6"
     uid-number "0.0.6"
@@ -3189,9 +3139,9 @@ npm-user-validate@^1.0.1:
   resolved "https://registry.yarnpkg.com/npm-user-validate/-/npm-user-validate-1.0.1.tgz#31428fc5475fe8416023f178c0ab47935ad8c561"
   integrity sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==
 
-"npm@https://github.com/pulsar-edit/npm-cli/releases/download/v6.14.19-pulsar/npm-6.14.19-pulsar.tgz":
-  version "6.14.19-pulsar"
-  resolved "https://github.com/pulsar-edit/npm-cli/releases/download/v6.14.19-pulsar/npm-6.14.19-pulsar.tgz#f7689fe88b46d6dc96f131641411669661eb8228"
+"npm@https://github.com/pulsar-edit/npm-cli/releases/download/v6.14.19-pulsar1-1/npm-6.14.19-pulsar1-1.tgz":
+  version "6.14.19-pulsar1-1"
+  resolved "https://github.com/pulsar-edit/npm-cli/releases/download/v6.14.19-pulsar1-1/npm-6.14.19-pulsar1-1.tgz#f4c29cfd8800c14ff5bba0c9316e3cdac655fbf6"
   dependencies:
     JSONStream "^1.3.5"
     abbrev "~1.1.1"
@@ -3233,8 +3183,8 @@ npm-user-validate@^1.0.1:
     is-cidr "^3.1.1"
     json-parse-better-errors "^1.0.2"
     lazy-property "~1.0.0"
-    libcipm "https://github.com/pulsar-edit/libcipm/releases/download/v4.0.9-pulsar/libcipm-4.0.9-pulsar.tgz"
-    libnpm "https://github.com/pulsar-edit/libnpm/releases/download/v3.0.2-pulsar/libnpm-3.0.2-pulsar.tgz"
+    libcipm "https://github.com/pulsar-edit/libcipm/archive/39984e5996e5dd14773e3433cc9d8c28fcf2aafa.tar.gz"
+    libnpm "https://github.com/pulsar-edit/libnpm/archive/214ce1e19008636e9637ff461d24f221dbe74a09.tar.gz"
     libnpmaccess "^3.0.2"
     libnpmhook "^5.0.3"
     libnpmorg "^1.0.1"
@@ -3253,13 +3203,13 @@ npm-user-validate@^1.0.1:
     mississippi "^3.0.0"
     mkdirp "^0.5.6"
     move-concurrently "^1.0.1"
-    node-gyp "^9.4.0"
+    node-gyp "https://github.com/nodejs/node-gyp/archive/d3615c66f7e7a65de48ce9860b1fe13710d20988.tar.gz"
     nopt "^4.0.3"
     normalize-package-data "^2.5.0"
     npm-audit-report "^1.3.3"
     npm-cache-filename "~1.0.2"
     npm-install-checks "^3.0.2"
-    npm-lifecycle "https://github.com/pulsar-edit/npm-lifecycle/releases/download/v3.1.6-pulsar/npm-lifecycle-3.1.6-pulsar.tgz"
+    npm-lifecycle "https://github.com/pulsar-edit/npm-lifecycle/archive/7d7d20ffbb596602c2ef6caaad9356413aa586ba.tar.gz"
     npm-package-arg "^6.1.1"
     npm-packlist "^1.4.8"
     npm-pick-manifest "^3.0.2"
@@ -3318,16 +3268,6 @@ npmlog@^4.1.2, npmlog@~4.1.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
-
-npmlog@^6.0.0:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-6.0.2.tgz#c8166017a42f2dea92d6453168dd865186a70830"
-  integrity sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==
-  dependencies:
-    are-we-there-yet "^3.0.0"
-    console-control-strings "^1.1.0"
-    gauge "^4.0.3"
-    set-blocking "^2.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -4233,7 +4173,7 @@ sigmund@~1.0.0:
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
   integrity sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==
 
-signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.7:
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -4411,7 +4351,7 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4940,7 +4880,7 @@ which@^1.2.9, which@^1.3.0, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
-which@^2.0.1, which@^2.0.2:
+which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
@@ -4954,7 +4894,7 @@ which@^3.0.0:
   dependencies:
     isexe "^2.0.0"
 
-wide-align@^1.1.0, wide-align@^1.1.5:
+wide-align@^1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
   integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,11 @@ abbrev@1, abbrev@^1.0.0, abbrev@~1.1.1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abbrev@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
+  integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
+
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -1708,6 +1713,17 @@ glob@^7.0.0, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, gl
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^8.0.3:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 global-dirs@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
@@ -2727,6 +2743,13 @@ minimatch@0.x:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.1.tgz#8a555f541cf976c622daf078bb28f29fb927c253"
@@ -2992,6 +3015,22 @@ node-gyp@^9.4.0:
     tar "^6.1.2"
     which "^2.0.2"
 
+"node-gyp@https://github.com/nodejs/node-gyp/archive/d3615c66f7e7a65de48ce9860b1fe13710d20988.tar.gz":
+  version "9.4.0"
+  uid "42925551931cf5b511c0755b1ad1c5aa876d36d3"
+  resolved "https://github.com/nodejs/node-gyp/archive/d3615c66f7e7a65de48ce9860b1fe13710d20988.tar.gz#42925551931cf5b511c0755b1ad1c5aa876d36d3"
+  dependencies:
+    env-paths "^2.2.0"
+    exponential-backoff "^3.1.1"
+    glob "^8.0.3"
+    graceful-fs "^4.2.6"
+    make-fetch-happen "^11.0.3"
+    nopt "^7.0.0"
+    proc-log "^3.0.0"
+    semver "^7.3.5"
+    tar "^6.1.2"
+    which "^3.0.0"
+
 nopt@^3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -3013,6 +3052,13 @@ nopt@^6.0.0:
   integrity sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==
   dependencies:
     abbrev "^1.0.0"
+
+nopt@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.0.tgz#067378c68116f602f552876194fd11f1292503d7"
+  integrity sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==
+  dependencies:
+    abbrev "^2.0.0"
 
 nopt@~1.0.10:
   version "1.0.10"
@@ -3601,6 +3647,11 @@ prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==
+
+proc-log@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-3.0.0.tgz#fb05ef83ccd64fd7b20bbe9c8c1070fc08338dd8"
+  integrity sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -4893,6 +4944,13 @@ which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-3.0.1.tgz#89f1cd0c23f629a8105ffe69b8172791c87b4be1"
+  integrity sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==
   dependencies:
     isexe "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,7 +1058,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-emissary@^1:
+emissary@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/emissary/-/emissary-1.3.3.tgz#a618d92d682b232d31111dc3625a5df661799606"
   integrity sha512-pD6FWNBSlEOzSJDCTcSGVLgNnGw5fnCvvGMdQ/TN43efeXZ/QTq8+hZoK3OOEXPRNjMmSJmeOnEJh+bWT5O8rQ==
@@ -1255,7 +1255,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-event-kit@^2.0.0, event-kit@^2.2.0:
+event-kit@^2.0.0, event-kit@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/event-kit/-/event-kit-2.5.3.tgz#d47e4bc116ec0aacd00263791fa1a55eb5e79ba1"
   integrity sha512-b7Qi1JNzY4BfAYfnIRanLk0DOD1gdkWHT4GISIn8Q2tAf3LpU8SP2CMwWaq40imYoKWbtN4ZhbSRxvsnikooZQ==
@@ -1401,19 +1401,6 @@ find-up@^3.0.0:
   integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
   dependencies:
     locate-path "^3.0.0"
-
-first-mate@^7.4.3:
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/first-mate/-/first-mate-7.4.3.tgz#058b9b6d2f43e38a5f0952669338cff2c46ae2dd"
-  integrity sha512-PtZUpaPmcV5KV4Rw5TfwczEnExN+X1o3Q/G82E4iRJ0tW91fm3Yi7pa5t4cBH8r3D6EyoBKvfpG2jKE+TZ0/nw==
-  dependencies:
-    emissary "^1"
-    event-kit "^2.2.0"
-    fs-plus "^3.0.0"
-    grim "^2.0.1"
-    oniguruma "^7.2.3"
-    season "^6.0.2"
-    underscore-plus "^1"
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -1755,7 +1742,7 @@ graceful-fs@^4.2.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
-grim@^2.0.1:
+grim@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/grim/-/grim-2.0.3.tgz#66e575efc4577981d959da0764926b4aaded4b0d"
   integrity sha512-FM20Ump11qYLK9k9DbL8yzVpy+YBieya1JG15OeH8s+KbHq8kL4SdwRtURwIUHniSxb24EoBUpwKfFjGNVi4/Q==
@@ -2942,7 +2929,7 @@ mv@2.1.1:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-nan@^2.14.0, nan@^2.14.2:
+nan@^2.14.2:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
   integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==
@@ -3073,7 +3060,6 @@ npm-install-checks@^3.0.2:
 
 "npm-lifecycle@https://github.com/pulsar-edit/npm-lifecycle/releases/download/v3.1.6-pulsar/npm-lifecycle-3.1.6-pulsar.tgz":
   version "3.1.6-pulsar"
-  uid af5e4b440656daeed01e10861460664c14b30d7b
   resolved "https://github.com/pulsar-edit/npm-lifecycle/releases/download/v3.1.6-pulsar/npm-lifecycle-3.1.6-pulsar.tgz#af5e4b440656daeed01e10861460664c14b30d7b"
   dependencies:
     byline "^5.0.0"
@@ -3355,13 +3341,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0, once@~1.4.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
-
-oniguruma@^7.2.3:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/oniguruma/-/oniguruma-7.2.3.tgz#e0b0b415302de8cdd6564e57a1a822ac0ab57012"
-  integrity sha512-PZZcE0yfg8Q1IvaJImh21RUTHl8ep0zwwyoE912KqlWVrsGByjjj29sdACcD1BFyX2bLkfuOJeP+POzAGVWtbA==
-  dependencies:
-    nan "^2.14.0"
 
 open@7.3.0:
   version "7.3.0"
@@ -4070,6 +4049,18 @@ season@^6.0.2:
     cson-parser "^1.3.0"
     fs-plus "^3.0.0"
     yargs "^3.23.0"
+
+"second-mate@https://github.com/pulsar-edit/second-mate.git#9686771":
+  version "8.0.0"
+  resolved "https://github.com/pulsar-edit/second-mate.git#9686771b4aa3159fe042528d60fcac3af3e1c655"
+  dependencies:
+    emissary "^1.3.3"
+    event-kit "^2.5.3"
+    fs-plus "^3.0.0"
+    grim "^2.0.3"
+    season "^6.0.2"
+    underscore-plus "^1"
+    vscode-oniguruma "^1.7.0"
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -4852,6 +4843,11 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vscode-oniguruma@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz#439bfad8fe71abd7798338d1cd3dc53a8beea94b"
+  integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
 
 walkdir@0.0.7:
   version "0.0.7"


### PR DESCRIPTION
## Reason for bumping node-gyp again (purpose of this PR)

There is an issue with code-signing apps built with node-gyp 9.1.0 or newer. (This is due to unforeseen consequences of a change I authored in node-gyp, unfortunately. The change in question: https://github.com/nodejs/node-gyp/commit/b9ddcd5bbd93b05b03674836b6ebdae2c2e74c8c.)

So, this PR bumps node-gyp to the latest commit from node-gyp repo's `main` branch, currently https://github.com/nodejs/node-gyp/commit/d3615c66f7e7a65de48ce9860b1fe13710d20988.

This includes a fix for better compatibility with app signing on macOS (https://github.com/nodejs/node-gyp/commit/0f1f667b737d21905e283df100a2cb639993562a).

Said commit with the fix isn't a part of any tagged or published-to-npm-package-registry releases yet, so we have to grab it from the node-gyp repo, rather than, say, as a version from the npm registry like we usually would.

## How to do this (how to bump node-gyp in our fork of npm --> how to bump node-gyp in ppm:

- Clone Pulsar's forks of [`npm-lifecycle`](https://github.com/pulsar-edit/npm-lifecycle), [`libnpm`](https://github.com/pulsar-edit/libnpm), [`libcipm`](https://github.com/pulsar-edit/libcipm), and [`npm`](https://github.com/pulsar-edit/npm-cli) (this last one has a custom repo name `npm-cli` for our fork. Because the upstream `cli` repo name is rather ambiguous otherwise.)
- Update the version of `node-gyp` in `npm-lifecycle`'s `package.json`. (Recommended to bump the version number of `npm-lifecycle` as well, to make it easier to track changes.) Publish these changes to Pulsar's fork of `npm-lifecycle`.
- Update the version of `npm-lifecycle` in `libnpm` and `libcipm`'s respective `package.json`s. (Bump versions of both packages.) Publish these changes to Pulsar's fork of each respective package.
- Update the versions of `npm-lifecycle`, `libnpm`, `libcipm` and `node-gyp` in `npm`'s `package.json`. (Bump `npm`'s version.) Publish these changes to Pulsar's fork of `npm` package.
  - Be careful about checking in changes to tracked files under `node_modules`. Unlike most NodeJS packages, the `node_modules` dir has some of its content checked in and changes tracked in git. This is so, when you clone the `npm` repo, it has a functional basic set of dependencies already, and can bootstrap itself.
    - Rule of thumb one: If after running `npx npm@6 install --ignore-scripts`, the files on-disk for any of the packages under node_modules have changed, _AND_ only if `git status` shows any of the package's files as `modified`, rather than all of them being `new file` or all of the package's files being listed under `Untracked files:`, then you should check in all the changes to files directly belonging to said package, but not any files under said package's own nested `node_modules` subfolder, unless those are already checked in and tracked as well.
    (Put more concisely: If a package has `modified` files under `git status`, update its checked-in files. Stage (`git add`) them and commit (`git commit`) them. And don't `git add` brand-new sub-dependencies that aren't already tracked in git -- ones that don't themselves show as `modified` in `git status`.
    - Rule of thumb number two: avoid checking in _brand new files_ under `node_modules`, unless they are genuinely part of the changed files in that package. Can confirm by checking the changed files at that package's git repo between the version you started with and the version you bumped to. Or alternatively, you can confirm by checking that the files in question are there if you download the package version in question with `npm pack [package_name]@[version]`, extracting the resulting tarball and inspecting the files -- you want to see that they match what you're going to commit, before committing them in `npm` repo. Add new files _only for a package that was tracked in git at the npm repo before you started_.
    - You can confirm/test that this all worked properly, if you can cleanly clone your changes and run `node . install` in the repo without errors, and have a large amount of the tests pass if you run `node . test` in the repo. I'm not aware of a way to avoid 100% of errors in the test suite, however. So, if most tests pass, that's what you're looking for.
- Once verified that the updated `npm` package is in good shape, run `npm pack` to package the `npm` package properly as a tarball. Publish this tarball as a release asset on Pulsar's fork of npm. (Without this, npm's sub-dependencies install wrong and are broken when you try to install it as a dependency of `ppm`).
- Finally, clone `ppm` repo, and bump `npm` and `node-gyp` in `ppm`'s `package.json`. Run `yarn install` and update the `yarn.lock` lockfile as well. Publish the branch where you made these changes, and post a pull request.

Note: _highly_ recommended to use npm 6 above, whenever running npm commands, since all the lockfiles for these packages are meant to be lockfile v1 format, which is the npm 6-era lockfile format.

## Context/tech debt notes

This is how we get newer node-gyp in ppm at the moment. Not easy, but this is the cost of tech debt and being indebted to npm 6-era technology (especially the "`require('npm')`", AKA "use npm all at once as a single library" thing that got significantly changed in npm 7 and then dropped altogether in npm 8).

(It's also the consequence of npm tending to require node-gyp all over the place in multiple, roundabout ways, given the way they split up slightly related modules that handle all this stuff on the npm side of things.)

Ideally, from a technical implementation stand-point, I feel we should find some way to use the underlying libraries that _make up_ npm as and where we need them. This has been discussed a bit on the Discord. Easier said than done.

For now, we have a fork on `npm`, one that hopefully we don't need to update all that often. (And especially we hopefully don't need to bump `node-gyp` very often, as it is one of the more painful/complicated dependencies to bump. For above-mentioned reasons.)

## Verification process

- [x] After cloning this branch, `yarn install` runs cleanly without updating `yarn.lock`, indicating dependencies are stable.
- [x] Running `yarn check` is mostly without errors.
  - (I get two errors about two sub-dependencies of `npm/node_modules/tar` allegedly being the wrong minor versions, but when I check on the version actually installed, they are the correct versions `yarn check` said it wanted to see??!?!).
    - `error "npm#tar#minipass" is wrong version: expected "2.9.0", got "2.3.3"` <-- I checked, 2.9.0 is installed on my machine???
    - `error "npm#tar#yallist" is wrong version: expected "3.1.1", got "3.0.3"` <-- I checked, 3.1.1 is installed on my machine???
  - (There are plenty of warnings of things we could dedupe, but deduping is kind of harder in Yarn than it is in npm, as far as I could ever tell. Maybe I missed the docs where there is any way to do so automatically. I suppose there is `yarn upgrade` and `yarn upgrade-interactive`... Not as urgent as having working dependencies, IMO. But could save some disk space and install time, ToDo later I guess, maybe, but low low priority.)
- [x] Tests pass locally and in CI. 