### PR TITLE
Revert "Skip update checks for bundled packages"

### DIFF
--- a/spec/upgrade-spec.js
+++ b/spec/upgrade-spec.js
@@ -76,23 +76,6 @@ describe('apm upgrade', () => {
     });
   });
 
-  it('does not display updates for "core" packages', () => {
-    fs.writeFileSync(path.join(packagesDir, 'core-package', 'package.json'), JSON.stringify({
-      name: 'core-package',
-      version: '1.0',
-      repository: 'https://github.com/pulsar-edit/pulsar'
-    }));
-    const callback = jasmine.createSpy('callback');
-    apm.run(['upgrade', '--list', '--no-color'], callback);
-
-    waitsFor('waiting for upgrade to complete', 600000, () => callback.callCount > 0);
-
-    runs(() => {
-      expect(console.log).toHaveBeenCalled();
-      expect(console.log.argsForCall[1][0]).toContain('empty');
-    });
-  });
-
   it('does not display updates for packages whose engine does not satisfy the installed Atom version', () => {
     fs.writeFileSync(path.join(packagesDir, 'test-module', 'package.json'), JSON.stringify({
       name: 'test-module',

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -93,12 +93,6 @@ available updates.\
     }
 
     getLatestVersion(pack, callback) {
-      // We want to bail on checking for updates of any packages that come with the editor
-      // This can generally be detected by checking if the repository is that of Pulsar itself
-      if (pack.repository === "https://github.com/pulsar-edit/pulsar") {
-        return callback();
-      }
-      
       const requestSettings = {
         url: `${config.getAtomPackagesUrl()}/${pack.name}`,
         json: true


### PR DESCRIPTION
Reverts pulsar-edit/ppm#91

We have discovered later on that this change doesn't actually need to happen.

Basically while the code is solid, the location packages are checked from to then check them for updates, would never include any actual bundled packages. Since those are all wrapped up in an asar, rather than the users `.packages` directory. 

So lets go ahead and revert it, to avoid complexity for complexities sake.