### PR TITLE
deps: Bump nan for compatibility with newer NodeJS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2153,9 +2153,9 @@
       }
     },
     "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "napi-build-utils": {
       "version": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2926,9 +2926,9 @@ mv@2.1.1:
     rimraf "~2.4.0"
 
 nan@^2.14.2:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
-  integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
+  integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
 
 napi-build-utils@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## Summary

Bump nan from 2.16.0 to 2.18.0. (Tiny, tiny, single-dependency bump in yarn.lock and package-lock.json only!)

(I recommend reviewers to check the diff to see that this is a super tiny PR.)

## Context: What is nan?

nan is a slightly more stable API target for compiling C/C++ addons for NodeJS projects against, attempting to hide the complexity and moving target that is the V8 engine internals beneath a more manageable, and once again a more "stable" API target.

For more info, see: https://github.com/nodejs/nan

## Why do we need to update it periodically?

We occasionally need to bump this package for compatibility with newer NodeJS versions that bundle newer versions of V8, or carry different V8 patches, etc. Newer nan versions get put out from time to time to address breakages in nan's "stable" API when used against the newer/different copies of V8 found in newer NodeJS versions. Newer Node+V8 versions come out and break stability in their C/C++ interfaces, newer nan versions come out to pave over the breakage and continue to provide a stable API target over time.

## Motivation for bumping this now

Allows us to bootstrap ppm on machines running the latest NodeJS 20.x

Remains untested whether ppm can fully run on NodeJS 20, but at least we know we can compile dependencies against NodeJS 14-20. Useful for keeping our Electron upgrade path smooth for the future. Not a perfect guarantee, but a *great* step to take nonetheless.

See: https://github.com/nodejs/release#release-schedule

## Related task for the repo: Add NodeJS 20 to the test matrix, drop NodeJS 14

We should add NodeJS 20 to the test matrix for this repo soon, and drop NodeJS 14

NodeJS 20 will be an LTS version starting in October. With this PR, we should be good to start testing against it now, if we want. It should be decently mature, given it'll be LTS soon. However, it would also make just about as much sense to wait for it to be actually LTS (and therefore have better stability guarantees as a moving target of minor and patch versions to test against).

And yeah, we should drop NodeJS 14 from the test matrix, it's been EOL for a while now.

In theory we should drop NodeJS 16, since it _just_ went EOL on September 11th, but since I think that version is still the best-supported version of Node to use around the various repos in Pulsar org, I think it's still worth testing, even if NodeJS 16 is also technically EOL already.

See: 
- https://github.com/nodejs/release#release-schedule
- https://nodejs.org/en/blog/announcements/nodejs16-eol

## Verification process

- [x] After this change, ppm can now be built locally on my machine with the `node` on my machine being the latest current NodeJS 20.6.1.
- [x] This shouldn't hurt compatibility with older NodeJS versions, so CI should pass!