### PR TITLE
Fix Error Handling

### DIFF
--- a/src/develop.js
+++ b/src/develop.js
@@ -61,7 +61,7 @@ cmd-shift-o to run the package out of the newly cloned repository.\
             return callback(`No repository URL found for package: ${packageName}`);
           }
         } else {
-          const message = request.getErrorMessage(error);
+          const message = request.getErrorMessage(body, error);
           return callback(`Request for package information failed: ${message}`);
         }
       });

--- a/src/featured.js
+++ b/src/featured.js
@@ -47,7 +47,7 @@ List the Pulsar packages and themes that are currently featured.\
           packages = _.sortBy(packages, 'name');
           return callback(null, packages);
         } else {
-          const message = request.getErrorMessage(error);
+          const message = request.getErrorMessage(body, error);
           return callback(`Requesting packages failed: ${message}`);
         }
       });

--- a/src/install.js
+++ b/src/install.js
@@ -221,7 +221,7 @@ Run ppm -v after installing Git to see what version has been detected.\
           if (error.status) { message += ` (${error.status})`; }
           return callback(message);
         } else if (response.statusCode !== 200) {
-          message = request.getErrorMessage(error);
+          message = request.getErrorMessage(body, error);
           return callback(`Request for package information failed: ${message}`);
         } else {
           if (body.releases.latest) {

--- a/src/publish.js
+++ b/src/publish.js
@@ -196,7 +196,7 @@ have published it.\
             if (error != null) {
               return callback(error);
             } else if (response.statusCode !== 201) {
-              const message = request.getErrorMessage(error);
+              const message = request.getErrorMessage(body, error);
               this.logFailure();
               return callback(`Registering package in ${repository} repository failed: ${message}`);
             } else {
@@ -237,7 +237,7 @@ have published it.\
           if (error != null) {
             return callback(error);
           } else if (response.statusCode !== 201) {
-            const message = request.getErrorMessage(error);
+            const message = request.getErrorMessage(body, error);
             return callback(`Creating new version failed: ${message}`);
           } else {
             return callback();

--- a/src/request.js
+++ b/src/request.js
@@ -101,11 +101,11 @@ module.exports = {
     });
   },
 
-  getErrorMessage(err) {
+  getErrorMessage(body, err) {
     if (err?.status === 503) {
       return `${err.response.req.host} is temporarily unavailable, please try again later.`;
     } else {
-      return err?.response?.body ?? err?.response?.error ?? err;
+      return err?.response?.body ?? err?.response?.error ?? err ?? body.message ?? body.error ?? body;
     }
   },
 

--- a/src/search.js
+++ b/src/search.js
@@ -54,7 +54,7 @@ Search for packages/themes.\
           packages = packages.filter(({name, version}) => !isDeprecatedPackage(name, version));
           return callback(null, packages);
         } else {
-          const message = request.getErrorMessage(error);
+          const message = request.getErrorMessage(body, error);
           return callback(`Searching packages failed: ${message}`);
         }
       });

--- a/src/star.js
+++ b/src/star.js
@@ -54,7 +54,7 @@ Run \`ppm stars\` to see all your starred packages.\
           return callback();
         } else if (response.statusCode !== 200) {
           this.logFailure();
-          const message = request.getErrorMessage(error);
+          const message = request.getErrorMessage(body, error);
           return callback(`Starring package failed: ${message}`);
         } else {
           this.logSuccess();

--- a/src/stars.js
+++ b/src/stars.js
@@ -61,7 +61,7 @@ List or install starred Atom packages and themes.\
           packages = _.sortBy(packages, 'name');
           return callback(null, packages);
         } else {
-          const message = request.getErrorMessage(error);
+          const message = request.getErrorMessage(body, error);
           return callback(`Requesting packages failed: ${message}`);
         }
       });

--- a/src/unstar.js
+++ b/src/unstar.js
@@ -42,7 +42,7 @@ Run \`ppm stars\` to see all your starred packages.\
           return callback(error);
         } else if (response.statusCode !== 204) {
           this.logFailure();
-          const message = body.message ?? body.error ?? body;
+          const message = request.getErrorMessage(body, error);
           return callback(`Unstarring package failed: ${message}`);
         } else {
           this.logSuccess();


### PR DESCRIPTION
It was brought to my attention on [Discord](https://discord.com/channels/992103415163396136/992110062992621598/1155591813785194626) that a61aa7e121bc93723f675198778b6006fdd66738 broke error handling in PPM.

The clue to find out what had gone wrong was the fact that the unstar command still worked.

This is because in that PR I had told `superagent` a list of status codes to not error on. This means that when we got, say a 404, the actual `error` object returned to the callback would be `null` even though those commands then relied on the `error` object to determine what had gone wrong. 

So what I've done, is provide both the `error` and `body` to the `request.getErrorMessage()` so that we can check for errors in either of them. 

Meaning when a request fails we will:
1. Look first for within the `superagent` error object for `err.response.body` then for `err.response.error` then for `err`
2. If that fails, we can then look at the body for `body.message` then `body.error` then finally `body`

This helpfully means we prioritize any errors returned by `superagent` then any errors returned by the backend. And if all else fails, we just tell the user whatever message was returned to us by the backend, which can be helpful in case the backend's error schema ever changes by accident or on purpose and isn't updated here. So that way we can always inform the user exactly what the backend is thinking.