### PR TITLE
src: Stop pinging backend during package uninstalls

### DIFF
--- a/src/uninstall.js
+++ b/src/uninstall.js
@@ -5,11 +5,9 @@ const async = require('async');
 const CSON = require('season');
 const yargs = require('yargs');
 
-const auth = require('./auth');
 const Command = require('./command');
 const config = require('./apm');
 const fs = require('./fs');
-const request = require('./request');
 
 module.exports =
 class Uninstall extends Command {


### PR DESCRIPTION
So, we stopped *using* these pings on our implementation of the backend, since it doesn't really make sense to decrement the install count when someone uninstalls... arguably. And it may or may not have simply been telemetry when the O.G. Atom backend was expecting this to be an authed action.

Since we don't need to auth or ping the backend for uninstalls... Just delete the code that does it!