### PR TITLE
src: Delete unused code in uninstall.js

### DIFF
--- a/src/uninstall.js
+++ b/src/uninstall.js
@@ -27,14 +27,6 @@ Delete the installed package(s) from the ~/.pulsar/packages directory.\
       return options.boolean('hard').describe('hard', 'Uninstall from ~/.pulsar/packages and ~/.pulsar/dev/packages');
     }
 
-    getPackageVersion(packageDirectory) {
-      try {
-        return CSON.readFileSync(path.join(packageDirectory, 'package.json'))?.version;
-      } catch (error) {
-        return null;
-      }
-    }
-
     async run(options) {
       options = this.parseOptions(options.commandArgs);
       const packageNames = this.packageNamesFromArgv(options.argv);

--- a/src/uninstall.js
+++ b/src/uninstall.js
@@ -2,7 +2,6 @@
 const path = require('path');
 
 const async = require('async');
-const CSON = require('season');
 const yargs = require('yargs');
 
 const Command = require('./command');

--- a/src/uninstall.js
+++ b/src/uninstall.js
@@ -59,7 +59,6 @@ Delete the installed package(s) from the ~/.pulsar/packages directory.\
             packageDirectory = path.join(packagesDirectory, packageName);
             const packageManifestPath = path.join(packageDirectory, 'package.json');
             if (fs.existsSync(packageManifestPath)) {
-              const packageVersion = this.getPackageVersion(packageDirectory);
               fs.removeSync(packageDirectory);
             } else if (!options.argv.hard) {
               throw new Error(`No package.json found at ${packageManifestPath}`);


### PR DESCRIPTION
This is a quick follow-up to some code removal in PR 103.

In #103, after removing some code that does a ping to the backend (which we no-op/ignore anyway, on the backend side...) I didn't notice `packageVersion` is now defined but unused with those code removals.

Basically this is one line I missed in the cleanup. Things that were part of making the backend ping work. With that removed, this line/variable serve no purpose.

This basically finishes the cleanup started in #103.

**(TL;DR: Another too-long writeup of a tiny diff. This is a one-liner removing a defined but unused var.)**

EDIT: Whoops, mentioned and tagged the wrong PR. This PR follows-up on PR 103, not PR 95...