### PR TITLE
src: Fix usage/help text (and error message) for -b/-t flags for ppm install

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -39,8 +39,8 @@ class Install extends Command {
 
 Usage: ppm install [<package_name>...]
        ppm install <package_name>@<package_version>
-       ppm install <git_remote> [-b <branch_or_tag_or_commit>]
-       ppm install <github_username>/<github_project> [-b <branch_or_tag_or_commit>]
+       ppm install <git_remote> [-b <branch_or_tag>]
+       ppm install <github_username>/<github_project> [-b <branch_or_tag>]
        ppm install --packages-file my-packages.txt
        ppm i (with any of the previous argument usage)
 

--- a/src/install.js
+++ b/src/install.js
@@ -565,7 +565,7 @@ Run ppm -v after installing Git to see what version has been detected.\
         const repo = Git.open(cloneDir);
         data.sha = version;
         const checked = repo.checkoutRef(`refs/tags/${version}`, false) || repo.checkoutReference(version, false);
-        if (!checked) { throw `Can't find the branch, tag, or commit referenced by ${version}`; }
+        if (!checked) { throw `Can't find the branch or tag referenced by ${version}`; }
       } else {
         const sha = this.getRepositoryHeadSha(cloneDir);
         data.sha = sha;


### PR DESCRIPTION
These flags do not *actually* take commit SHAs as arguments, only branch or tag names.

The flags are aliases of one-another and work the exact same -- *either* flag can take a branch name *or* tag name. No SHAs.

---

Optional context: Issue report https://github.com/pulsar-edit/pulsar/issues/821 over at the core repo brought this back to my attention, although I believe it had been brought up somewhere in Discord a long time ago, just now getting around to finally updating the usage/help text to be accurate.