### PR TITLE
Fix Newer NodeJS CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,14 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Setup Python (NodeJS v14)
+        # While initially tests would pass with no Python setup, additional testing
+        # is showing issues with CI included Python versions, so we will install our own
+        if: ${{ matrix.node_version == 14 }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - name: Install Python Dependencies
         # NodeJS v14 doesn't have a newer copy of python, so we don't need to install deps
         if: ${{ matrix.node_version != 14 }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,16 @@ jobs:
           architecture: ${{ matrix.node_arch }}
           check-latest: true
 
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install Python Dependencies
+        # This is needed for Python 3.12+, since node-gyp requires
+        # 'distutils', which has been removed
+        run: python3 -m pip install setuptools
+        
       - name: Install dependencies
         run: |
           # Yarn v1.x needs global node-gyp available if npm 9.7.2+ is the global npm version,

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,15 +34,19 @@ jobs:
           check-latest: true
 
       - name: Setup Python
+        # NodeJS v14 can use the python included by the CI
+        if: ${{ matrix.node_version != 14 }}
         uses: actions/setup-python@v4
         with:
           python-version: '3.12'
 
       - name: Install Python Dependencies
+        # NodeJS v14 doesn't have a newer copy of python, so we don't need to install deps
+        if: ${{ matrix.node_version != 14 }}
         # This is needed for Python 3.12+, since node-gyp requires
         # 'distutils', which has been removed
         run: python3 -m pip install setuptools
-        
+
       - name: Install dependencies
         run: |
           # Yarn v1.x needs global node-gyp available if npm 9.7.2+ is the global npm version,


### PR DESCRIPTION
This PR aims to resolve the CI issues we are seeing on this repo.

As activity has been spares over here, seems this repo had never yet received the new `setuptools` and Python 3.12+ actions logic.

So this PR simply takes what's mostly used over at Pulsar, and adds it's logic to the CI here.