### PR TITLE
Add Codacy and Friends Configuration

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,34 @@
+---
+engines:
+  duplication:
+    minTokenMatch: 80
+exclude_paths:
+  - "spec/fixtures/**"
+  - "templates/**"
+
+# Since Codacy exposes significantly little on the config.
+# We can use the rest of this document to solidify our settings.
+#
+# Quality Settings: (Below are changed values, rest are default)
+#   * Pull requests won't pass the quality gate when:
+#     - New issues are over: 15 'critical'
+#   * Commits won't pass the quality gate:
+#     - New issues are over: 15 'critical'
+#   * The repository is below the quality goals when:
+#     - Issues are over: 20%
+#     - Complexity is over: 10%
+#     - File is complex when over: 20
+#     - Duplication is over: 30
+#     - File is duplicated when over: 1 'cloned block'
+#     - Coverage is under: 60%
+# Enabled Engines:
+#   - CSSLint 1.0.5
+#   - CoffeeLint 2.1.0
+#   - ESLint 8.23.1
+#   - Hadolint 1.18.2
+#   - Jackson Linter 2.10.2
+#   - PMD 6.48.0
+#   - Semgrep: 1.50.0
+#   - ShellCheck 0.8.0
+#   - Stylelint 14.2.0
+#

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,38 @@
+module.exports = {
+  env: {
+    browser: false,
+    commonjs: true,
+    es2021: true
+  },
+  extends: [
+    "eslint:recommended",
+    "plugin:node/recommended"
+  ],
+  overrides: [],
+  parserOptions: {
+    ecmaVersion: "latest"
+  },
+  rules: {
+    "space-before-function-paren": [ "error", {
+      anonymous: "always",
+      asyncArrow: "always",
+      named: "never"
+    }],
+    "prettier/prettier": "off",
+    "ember-suave/lines-between-object-propertiess": "off",
+    "no-empty": "off"
+  },
+  plugins: [],
+  globals: {
+    "describe": "readonly",
+    "it": "readonly",
+    "runs": "readonly",
+    "expect": "readonly",
+    "beforeEach": "readonly",
+    "afterEach": "readonly",
+    "silenceOutput": "readonly",
+    "spyOn": "readonly",
+    "spyOnToken": "readonly",
+    "waitsFor": "readonly"
+  }
+};


### PR DESCRIPTION
This PR adds a Codacy and ESlint config.

ESlint is included within Codacy, so we want to configure them really at the same time to ensure things work how we expect.

Much of the config of both has been taken directly from the Pulsar config, to ensure a relatively seamless flow between the two. This configuration will still keep Codacy out of the way, only reporting on the PR a score (Although this PR makes Codacy more out of the way than now, by fine tuning that score to be even less aggressive.)

Additionally, we are fine tuning some of the enabled rules within ESlint to ensure we only get alerts about the things we care about, where I've gone ahead and disabled the overzealous or especially opinionated rules that we have alerts for.