### PR TITLE
Fix placement of `setTimeout`

### DIFF
--- a/src/publish.js
+++ b/src/publish.js
@@ -128,9 +128,9 @@ have published it.\
               if (--retryCount <= 0) {
                 return void resolve();
               }
+              setTimeout(requestTags, interval);
             }
-          )
-          setTimeout(requestTags, interval);
+          );
         };
         requestTags();
       });


### PR DESCRIPTION
The command was hanging because `setTimeout` was being called over and over, rather than just as needed (because the tag wasn't available yet). The `setTimeout` started out in one wrong place and then I “fixed” it by moving the `setTimeout` to a _different_ wrong place.

There is a separate issue here: the API calls to GitHub could fail for any number of reasons. One reason they failed for me was because I exceeded the unauthenticated rate limit! This command should at least handle the error cases, but I believe it can also use the very auth token we use for the package backend in order to enable a much higher rate limit. Both of those are worth doing, but I'll save them for a different PR.