### PR TITLE
Removing "No Operand in Assignment" Usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,10 @@ module.exports = {
     }],
     "prettier/prettier": "off",
     "ember-suave/lines-between-object-propertiess": "off",
-    "no-empty": "off"
+    "no-empty": "off",
+    "no-unused-vars": [ "error", {
+      argsIgnorePattern: "^_"
+    }]
   },
   plugins: [],
   globals: {

--- a/src/apm-cli.js
+++ b/src/apm-cli.js
@@ -255,8 +255,8 @@ module.exports = {
           showHelp(options);
         }
         return errorHandler();
-      } else if (commands[command]) {
-        Command = commands[command];
+      } else if ((Command = commands[command])) {
+        //Command = commands[command];
         const command = new Command();
         return command.run(options).then(errorHandler);
       } else {

--- a/src/apm-cli.js
+++ b/src/apm-cli.js
@@ -180,9 +180,9 @@ function getPythonVersion() {
         const pythonExe = path.resolve(rootDir, 'Python27', 'python.exe');
         if (fs.isFileSync(pythonExe)) { python = pythonExe; }
       }
-  
+
       python ??= 'python';
-  
+
       const spawned = spawn(python, ['--version']);
       const outputChunks = [];
       spawned.stderr.on('data', chunk => outputChunks.push(chunk));
@@ -239,7 +239,8 @@ module.exports = {
     if (args.version) {
       return printVersions(args).then(errorHandler);
     } else if (args.help) {
-      if ((Command = commands[options.command])) {
+      if (commands[options.command]) {
+        Command = commands[options.command];
         showHelp(new Command().parseOptions?.(options.command));
       } else {
         showHelp(options);
@@ -247,13 +248,15 @@ module.exports = {
       return errorHandler();
     } else if (command) {
       if (command === 'help') {
-        if ((Command = commands[options.commandArgs])) {
+        if (commands[options.commandArgs]) {
+          Command = commands[options.commandArgs];
           showHelp(new Command().parseOptions?.(options.commandArgs));
         } else {
           showHelp(options);
         }
         return errorHandler();
-      } else if ((Command = commands[command])) {
+      } else if (commands[command]) {
+        Command = commands[command];
         const command = new Command();
         return command.run(options).then(errorHandler);
       } else {

--- a/src/install.js
+++ b/src/install.js
@@ -243,8 +243,7 @@ Run ppm -v after installing Git to see what version has been detected.\
     //  * packageVersion: The string version of the package.
     isPackageInstalled(packageName, packageVersion) {
       try {
-        let left;
-        const {version} = (left = CSON.readFileSync(CSON.resolve(path.join('node_modules', packageName, 'package')))) != null ? left : {};
+        const { version } = CSON.readFileSync(CSON.resolve(path.join('node_modules', packageName, 'package'))) ?? {};
         return packageVersion === version;
       } catch (error) {
         return false;
@@ -399,10 +398,9 @@ Run ppm -v after installing Git to see what version has been detected.\
     // Get all package dependency names and versions from the package.json file.
     getPackageDependencies(cloneDir) {
       try {
-        let left;
         const fileName = path.join((cloneDir || '.'), 'package.json');
         const metadata = fs.readFileSync(fileName, 'utf8');
-        const {packageDependencies, dependencies} = (left = JSON.parse(metadata)) != null ? left : {};
+        const { packageDependencies, dependencies } = JSON.parse(metadata) ?? {};
 
         if (!packageDependencies) { return {}; }
         if (!dependencies) { return packageDependencies; }
@@ -462,7 +460,7 @@ Run ppm -v after installing Git to see what version has been detected.\
 
       fs.removeSync(path.resolve(__dirname, '..', 'native-module', 'build'));
 
-      return new Promise((resolve, reject) => 
+      return new Promise((resolve, reject) =>
         void this.fork(this.atomNpmPath, buildArgs, buildOptions, (...args) =>
           void this.logCommandResults(...args).then(resolve, reject)
         )
@@ -679,7 +677,7 @@ Run ppm -v after installing Git to see what version has been detected.\
           await this.installDependencies(options);
           return;
         }
-        
+
         // is registered package
         let version;
         const atIndex = name.indexOf('@');

--- a/src/list.js
+++ b/src/list.js
@@ -106,15 +106,14 @@ List all the installed packages and also the packages bundled with Atom.\
     listPackages(directoryPath, options) {
       const packages = [];
       for (let child of Array.from(fs.list(directoryPath))) {
-        var manifestPath;
         if (!fs.isDirectorySync(path.join(directoryPath, child))) { continue; }
         if (child.match(/^\./)) { continue; }
         if (!options.argv.links) {
           if (fs.isSymbolicLinkSync(path.join(directoryPath, child))) { continue; }
         }
 
-        let manifest = null;
-        if (manifestPath = CSON.resolve(path.join(directoryPath, child, 'package'))) {
+        let manifestPath = CSON.resolve(path.join(directoryPath, child, 'package'));
+        if (manifestPath) {
           try {
             manifest = CSON.readFileSync(manifestPath);
           } catch (error) {}

--- a/src/list.js
+++ b/src/list.js
@@ -112,6 +112,7 @@ List all the installed packages and also the packages bundled with Atom.\
           if (fs.isSymbolicLinkSync(path.join(directoryPath, child))) { continue; }
         }
 
+        let manifest = null;
         let manifestPath = CSON.resolve(path.join(directoryPath, child, 'package'));
         if (manifestPath) {
           try {

--- a/src/publish.js
+++ b/src/publish.js
@@ -314,7 +314,7 @@ have published it.\
       }
 
 
-      if (currentBranch = repo.getShortHead()) {
+      if (currentBranch == repo.getShortHead()) {
         remoteName = repo.getConfigValue(`branch.${currentBranch}.remote`);
       }
       if (remoteName == null) { remoteName = repo.getConfigValue('branch.master.remote'); }

--- a/src/publish.js
+++ b/src/publish.js
@@ -314,7 +314,8 @@ have published it.\
       }
 
 
-      if (currentBranch == repo.getShortHead()) {
+      currentBranch = repo.getShortHead();
+      if (currentBranch) {
         remoteName = repo.getConfigValue(`branch.${currentBranch}.remote`);
       }
       if (remoteName == null) { remoteName = repo.getConfigValue('branch.master.remote'); }

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -52,7 +52,7 @@ available updates.\
     getInstalledPackages(options) {
       let packages = [];
       for (let name of fs.list(this.atomPackagesDirectory)) {
-        let pack = this.getInstalledPackage(name);
+        let pack = this.getIntalledPackage(name);
         if (pack) {
           packages.push(pack);
         }

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -52,8 +52,8 @@ available updates.\
     getInstalledPackages(options) {
       let packages = [];
       for (let name of fs.list(this.atomPackagesDirectory)) {
-        var pack;
-        if (pack = this.getIntalledPackage(name)) {
+        let pack = this.getInstalledPackage(name);
+        if (pack) {
           packages.push(pack);
         }
       }
@@ -148,7 +148,7 @@ available updates.\
       git.addGitToEnv(process.env);
       return new Promise((resolve, reject) => {
         this.spawn(command, args, {cwd: repoPath}, (code, stderr, stdout) => {
-          stderr ??= ''; 
+          stderr ??= '';
           stdout ??= '';
           if (code !== 0) {
             return void reject(new Error('Exit code: ' + code + ' - ' + stderr));


### PR DESCRIPTION
With PPM now properly setup on Codacy, the next two biggest suggestions are the following:

* No Unused Vars: For this one I've added a small bit of configuration to the eslint config file, to not apply this rule if the variable begins with an underscore, which should solve solve that issue by and large for us.
* No Assignment in Operand: This issue is less invasive than it appears. While there are some instances where variables are assigned a value within an operand, other situations were found such as old CoffeeScript `is not` operators that weren't decaffed cleanly, and also a single instance of what appears to be a typo of `=` rather than `==`

With this issues addressed, we don't expect to see any change in hope behavior ourselves.