### PR TITLE
feat(link): add --force flag

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -25,6 +25,7 @@ Run \`ppm links\` to view all the currently linked packages.\
 `
       );
       options.alias('h', 'help').describe('help', 'Print this usage message');
+      options.alias('f', 'force').boolean('force').describe('force', 'Remove the target path before linking');
       return options.alias('d', 'dev').boolean('dev').describe('dev', 'Link to ~/.pulsar/dev/packages');
     }
 
@@ -50,6 +51,9 @@ Run \`ppm links\` to view all the currently linked packages.\
 
       try {
         if (fs.isSymbolicLinkSync(targetPath)) { fs.unlinkSync(targetPath); }
+        else if (options.argv.force && fs.existsSync(targetPath)) {
+            fs.rmSync(targetPath, { recursive: true, force: true });
+        }
         fs.makeTreeSync(path.dirname(targetPath));
         fs.symlinkSync(linkPath, targetPath, 'junction');
         console.log(`${targetPath} -> ${linkPath}`);


### PR DESCRIPTION
Hi there, now that I'm using Pulsar, I find myself with a fair number of old Atom packages that need tweaks or updates, and so I'm doing this dance a lot:
```
$ git clone $PACKAGE_THAT_NEEDS_A_FIX_OR_UPDATE
$ cd $PACKAGE_THAT_NEEDS_A_FIX_OR_UPDATE
$ npm i
$ ppm link
Linking $CURRENTLY_INSTALLED_PACKAGE to $PACKAGE_THAT_NEEDS_A_FIX_OR_UPDATE failed: EEXIST: file already exists, symlink '$PACKAGE_THAT_NEEDS_A_FIX_OR_UPDATE' -> '$CURRENTLY_INSTALLED_PACKAGE'

# dang it!
```

Obviously, the fix is simple and easy (`rm -rf $CURRENTLY_INSTALLED_PACKAGE` & try again), but it also felt like a `--force` flag would be handy to just do that for me while rerunning the command.

This was a pretty trivial change, and I'm happy to make changes as desired. I added 2 tests: one to confirm that it errors if the target exists, and another to confirm that it nukes it and then links when used with the `--force` flag.

### Alternatives
I briefly considered calling it `link --triforce`. ⚔️ 

Thank you!