### PR TITLE
Update syntax-variables.less to include language entity colors

### DIFF
--- a/templates/theme/styles/syntax-variables.less
+++ b/templates/theme/styles/syntax-variables.less
@@ -29,3 +29,19 @@
 @syntax-color-added: @green;
 @syntax-color-modified: @orange;
 @syntax-color-removed: @red;
+
+// For language entity colors
+@syntax-color-variable: @cyan;
+@syntax-color-comment: @green;
+@syntax-color-constant: @purple;
+@syntax-color-property: @orange;
+@syntax-color-value: @green;
+@syntax-color-function: @orange;
+@syntax-color-method: @syntax-color-function;
+@syntax-color-class: @orange;
+@syntax-color-keyword: @red;
+@syntax-color-tag: @red;
+@syntax-color-attribute: @orange;
+@syntax-color-import: @light-orange;
+@syntax-color-snippet: @green;
+@syntax-color-string: @green;


### PR DESCRIPTION
Suppose you've written a package that makes some sort of editor enhancement. For various reasons, you'd _really_ like to know what color is used to highlight variables in their syntax theme.

The good news is that Pulsar defines a list of variables in `syntax-variables.less` in each of the eight built-in themes which lists this token and others. (Amazingly, not all of them _actually consume_ these variables in the rest of the stylesheets, so it may only be coincidental when the values line up; but B+ for effort.) Pulsar also [defines some fallback values](https://github.com/pulsar-edit/pulsar/commit/91710894660018988cfa87c5132333129dd1f0c6) so that these values can at least be used consistently in a user's stylesheet file, and in any package stylesheet, without Less complaining about an undefined variable.

Somehow, though, these variables never made it to the template that PPM uses to generate new syntax themes. I've fixed that here. I've also taken the liberty of adding two variables — `@syntax-color-comment` and `@syntax-color-string` — that I _can't believe_ were excluded from this list initially.

Will this make much of a difference when most community themes aren't actively maintained? Maybe not. But the best time to plant a tree was back in 2015 (when some other trees were planted in a different repository) and the second best time is now.