### PR TITLE
Fix test failure due to missing atom command

### DIFF
--- a/spec/test-spec.js
+++ b/spec/test-spec.js
@@ -30,8 +30,8 @@ describe('apm test', () => {
     waitsFor('waiting for test to complete', () => atomSpawn.callCount === 1);
 
     runs(() => {
-      // On Windows, there's a suffix (atom.cmd), so we only check that atom is _included_ in the path
-      expect(atomSpawn.mostRecentCall.args[0].indexOf('atom')).not.toBe(-1);
+      // On Windows, there's a suffix (pulsar.cmd), so we only check that pulsar is _included_ in the path
+      expect(atomSpawn.mostRecentCall.args[0].indexOf('pulsar')).not.toBe(-1);
       expect(atomSpawn.mostRecentCall.args[1][0]).toEqual('--dev');
       expect(atomSpawn.mostRecentCall.args[1][1]).toEqual('--test');
       expect(atomSpawn.mostRecentCall.args[1][2]).toEqual(specPath);

--- a/src/test.js
+++ b/src/test.js
@@ -33,7 +33,7 @@ to the current working directory).\
 
       if (options.argv.path) { atomCommand = options.argv.path; }
       if (!fs.existsSync(atomCommand)) {
-        atomCommand = 'atom';
+        atomCommand = 'pulsar';
         if (process.platform === 'win32') { atomCommand += '.cmd'; }
       }
 


### PR DESCRIPTION
If pulsar is installed from the .deb package,
the command `ppm test` fails with this error:

`Error spawning atom: spawn atom ENOENT`

Using `pulsar` instead of `atom` fixes this.