### PR TITLE
Revert "CI: Work around a weird bug in Yarn v1.x"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,11 +56,7 @@ jobs:
         run: python3 -m pip install setuptools
 
       - name: Install dependencies
-        run: |
-          # Yarn v1.x needs global node-gyp available if npm 9.7.2+ is the global npm version,
-          # or else postinstall scripts for this repo won't run. It's a long story. And it's a "won't fix" bug in Yarn v1.x.
-          yarn global add node-gyp@9.4.0
-          yarn install
+        run: yarn install
 
       - if: "!contains(matrix.os, 'windows')"
         name: Run tests 👩🏾‍💻


### PR DESCRIPTION
## Change, Rationale and Context

### Change

This reverts commit 12c276b6233cba8ec60bccfe58bc33c618e0de60.

### Background/Context

Revert a now-unnecessary workaround.

Amazingly, this issue has been avoided in the latest npm versions, as npm have restored the files Yarn 1.x rather over-optimistically required npm to have.

NodeJS has in turn bundled these versions of npm with the fixes before the final minor/patch release of every major version of NodeJS.

This is effectively a solved issue if you use the latest patch versions of NodeJS. No more incompatibility with Yarn 1.x in these narrow cases.

(Admittedly, the Yarn 1.x issue was due to a genuine bug in Yarn 1.x, not a deliberate thing from the Yarn authors I don't think).

---

## Research Notes

See this comment for all the (somewhat exhaustive!) research I did to support making this change: https://github.com/npm/cli/pull/6554#issuecomment-2101089494

Side note: Reverting the workaround is possible now that the Yarn 1.x issue has been effectively (and rather graciously) resolved by npm and NodeJS, even though it's to keep compatibility with a rather strange decision Yarn 1.x's authors made (+ an inadvertent bug in Yarn 1.x's code, it would seem) several years ago now in a now-essentially-frozen codebase. _**Thank you npm team for making the best move for the ecosystem, even if it means leaving a bit of cruft around in your own flagship project's repository!**_