### PR TITLE
Rewrite publish logic

### DIFF
--- a/spec/publish-spec.js
+++ b/spec/publish-spec.js
@@ -201,8 +201,7 @@ describe('apm publish', () => {
     apm.run(['publish', 'patch'], callback);
     waitsFor('waiting for publish to complete', 600000, () => callback.callCount === 1);
     runs(() => {
-      console.log(requests);
-      expect(requests.length).toBe(2);
+      expect(requests.length).toBe(1);
       expect(callback.mostRecentCall.args[0]).toBeUndefined();
     });
   });

--- a/spec/publish-spec.js
+++ b/spec/publish-spec.js
@@ -201,6 +201,7 @@ describe('apm publish', () => {
     apm.run(['publish', 'patch'], callback);
     waitsFor('waiting for publish to complete', 600000, () => callback.callCount === 1);
     runs(() => {
+      console.log(requests);
       expect(requests.length).toBe(2);
       expect(callback.mostRecentCall.args[0]).toBeUndefined();
     });

--- a/src/publish.js
+++ b/src/publish.js
@@ -424,13 +424,17 @@ have published it.\
       let {tag, rename, verbose} = options.argv;
       let [version] = options.argv._;
 
+      // Normalize variables to ensure they are strings with zero length
+      // rather than their default `undefined`
+      // This ensures later length checks always behave as expected
       if (typeof tag !== "string") {
-        // prevent tag from being undefined, and make it a string with 0 length
         tag = "";
       }
       if (typeof version !== "string") {
-        // prevent tag from being undefined, and make it a string with 0 length
         version = "";
+      }
+      if (typeof rename !== "string") {
+        rename = "";
       }
 
       if (verbose) {

--- a/src/publish.js
+++ b/src/publish.js
@@ -453,13 +453,13 @@ have published it.\
         return error;
       }
 
-      if (version?.length === 0 && tag?.length === 0 && rename?.length === 0) {
+      if (version.length === 0 && tag.length === 0 && rename.length === 0) {
         return "A version, tag, or new package name is required";
       }
 
-      if (rename?.length > 0) {
+      if (rename.length > 0) {
         // A version isn't required when renaming a package (apparently)
-        if (version?.length === 0) { version = "patch"; }
+        if (version.length === 0) { version = "patch"; }
         originalName = pack.name;
 
         try {
@@ -472,7 +472,7 @@ have published it.\
       // Now we know a version has been specified, and that we have settled any
       // rename concerns. Lets get to publication
 
-      if (tag?.length === 0) {
+      if (tag.length === 0) {
         // only create and assign a tag if the user didn't specify one.
         // if they did we assume that tag already exists and only work to publish
         try {

--- a/src/publish.js
+++ b/src/publish.js
@@ -359,7 +359,7 @@ have published it.\
           this.spawn(gitCommand, ['commit', '-m', message], (code, stderr, stdout) => {
             stderr ??= '';
             stdout ??= '';
-            if (code === 0) {
+            if (code !== 0) {
               this.logFailure();
               const commitOutput = `${stdout}\n${stderr}`.trim();
               reject(`Failed to commit package.json: ${commitOutput}`);
@@ -440,7 +440,7 @@ have published it.\
         return error;
       }
 
-      if (!version?.length > 0 && !tag?.length > 0) {
+      if (!version?.length > 0 && !tag?.length > 0 && !rename?.length > 0) {
         return "A version, tag, or new package name is required";
       }
 

--- a/src/publish.js
+++ b/src/publish.js
@@ -254,24 +254,6 @@ have published it.\
       });
     }
 
-    async doesPackageExist(pack) {
-      const packageName = pack.name;
-      const requestSettings = {
-        url: `${config.getAtomPackagesUrl()}/${packageName}`,
-        json: true
-      };
-      request.get(requestSettings, (error, response, body) => {
-        if (error != null) {
-          throw error;
-        }
-        if (response.statusCode === 200) {
-          return true;
-        } else {
-          return false;
-        }
-      });
-    }
-
     // Publish the version of the package associated with the given tag.
     //
     // pack - The package metadata.
@@ -488,7 +470,7 @@ have published it.\
 
       let doesPackageExist;
       try {
-        doesPackageExist = this.doesPackageExist(pack);
+        doesPackageExist = await this.packageExists(pack.name);
       } catch(error) {
         return error;
       }

--- a/src/publish.js
+++ b/src/publish.js
@@ -446,7 +446,7 @@ have published it.\
 
       if (rename?.length > 0) {
         // A version isn't required when renaming a package (apparently)
-        if (version?.length <= 0) { version = "path"; }
+        if (version?.length <= 0) { version = "patch"; }
         originalName = pack.name;
 
         try {

--- a/src/publish.js
+++ b/src/publish.js
@@ -428,6 +428,10 @@ have published it.\
         // prevent tag from being undefined, and make it a string with 0 length
         tag = "";
       }
+      if (typeof version !== "string") {
+        // prevent tag from being undefined, and make it a string with 0 length
+        version = "";
+      }
 
       if (verbose) {
         process.stdout.write("Attempting to publish package with the following options:");

--- a/src/publish.js
+++ b/src/publish.js
@@ -440,7 +440,7 @@ have published it.\
         return error;
       }
 
-      if (!version?.length > 0) {
+      if (!version?.length > 0 && !tag?.length > 0) {
         return "A version, tag, or new package name is required";
       }
 

--- a/src/publish.js
+++ b/src/publish.js
@@ -459,14 +459,18 @@ have published it.\
       // Now we know a version has been specified, and that we have settled any
       // rename concerns. Lets get to publication
 
-      try {
-        tag = await this.versionPackage(version);
-        await this.pushVersion(tag, pack);
-      } catch(error) {
-        return error;
-      }
+      if (!tag?.length > 0) {
+        // only create and assign a tag if the user didn't specify one.
+        // if they did we assume that tag already exists and only work to publish
+        try {
+          tag = await this.versionPackage(version);
+          await this.pushVersion(tag, pack);
+        } catch(error) {
+          return error;
+        }
 
-      await this.waitForTagToBeAvailable(pack, tag);
+        await this.waitForTagToBeAvailable(pack, tag);
+      }
 
       let doesPackageExist;
       try {

--- a/src/publish.js
+++ b/src/publish.js
@@ -30,6 +30,7 @@ class Publish extends Command {
 Usage: ppm publish [<newversion> | major | minor | patch | build]
        ppm publish --tag <tagname>
        ppm publish --rename <new-name>
+       ppm publish --verbose
 
 Publish a new version of the package in the current working directory.
 
@@ -51,6 +52,7 @@ have published it.\
       );
       options.alias('h', 'help').describe('help', 'Print this usage message');
       options.alias('t', 'tag').string('tag').describe('tag', 'Specify a tag to publish. Must be of the form vx.y.z');
+      options.alias('v', 'verbose').string('verbose').describe('verbose', 'Log extras details during publication');
       return options.alias('r', 'rename').string('rename').describe('rename', 'Specify a new name for the package');
     }
 
@@ -419,8 +421,13 @@ have published it.\
     async run(options) {
       let pack, originalName;
       options = this.parseOptions(options.commandArgs);
-      let {tag, rename} = options.argv;
+      let {tag, rename, verbose} = options.argv;
       let [version] = options.argv._;
+
+      if (verbose) {
+        process.stdout.write("Attempting to publish package with the following options:");
+        process.stdout.write(JSON.stringify(options, null, 2));
+      }
 
       try {
         pack = this.loadMetadata();

--- a/src/publish.js
+++ b/src/publish.js
@@ -424,6 +424,11 @@ have published it.\
       let {tag, rename, verbose} = options.argv;
       let [version] = options.argv._;
 
+      if (typeof tag !== "string") {
+        // prevent tag from being undefined, and make it a string with 0 length
+        tag = "";
+      }
+
       if (verbose) {
         process.stdout.write("Attempting to publish package with the following options:");
         process.stdout.write(JSON.stringify(options, null, 2));
@@ -447,7 +452,7 @@ have published it.\
         return error;
       }
 
-      if (!version?.length > 0 && !tag?.length > 0 && !rename?.length > 0) {
+      if (version?.length <= 0 && tag?.length <= 0 && rename?.length <= 0) {
         return "A version, tag, or new package name is required";
       }
 
@@ -466,7 +471,7 @@ have published it.\
       // Now we know a version has been specified, and that we have settled any
       // rename concerns. Lets get to publication
 
-      if (!tag?.length > 0) {
+      if (tag?.length <= 0) {
         // only create and assign a tag if the user didn't specify one.
         // if they did we assume that tag already exists and only work to publish
         try {

--- a/src/publish.js
+++ b/src/publish.js
@@ -477,8 +477,6 @@ have published it.\
       // Now we know a version has been specified, and that we have settled any
       // rename concerns. Lets get to publication
 
-      let tag;
-
       try {
         tag = await this.versionPackage(version);
         await this.pushVersion(tag, pack);

--- a/src/publish.js
+++ b/src/publish.js
@@ -487,15 +487,8 @@ have published it.\
       }
 
       await this.waitForTagToBeAvailable(pack, tag);
-      if (originalName != null) {
-        // If we're renaming a package, we have to hit the API with the
-        // current name, not the new one, or it will 404.
-        rename = pack.name;
-        pack.name = originalName;
-      }
 
       let doesPackageExist;
-
       try {
         doesPackageExist = this.doesPackageExist(pack);
       } catch(error) {
@@ -506,6 +499,10 @@ have published it.\
         // This is an existing package we just want to publish a new version of
         try {
           if (originalName != null) {
+            // If we're renaming a package, we have to hit the API with the
+            // current name, not the new one, or it will 404.
+            rename = pack.name;
+            pack.name = originalName;
             await this.publishPackage(pack, tag, {rename});
           } else {
             await this.publishPackage(pack, tag);

--- a/src/publish.js
+++ b/src/publish.js
@@ -52,7 +52,7 @@ have published it.\
       );
       options.alias('h', 'help').describe('help', 'Print this usage message');
       options.alias('t', 'tag').string('tag').describe('tag', 'Specify a tag to publish. Must be of the form vx.y.z');
-      options.alias('v', 'verbose').string('verbose').describe('verbose', 'Log extras details during publication');
+      options.boolean('v').alias('v', 'verbose').describe('verbose', 'Log extra details during publication');
       return options.alias('r', 'rename').string('rename').describe('rename', 'Specify a new name for the package');
     }
 

--- a/src/publish.js
+++ b/src/publish.js
@@ -460,13 +460,13 @@ have published it.\
         return error;
       }
 
-      if (version?.length <= 0 && tag?.length <= 0 && rename?.length <= 0) {
+      if (version?.length === 0 && tag?.length === 0 && rename?.length === 0) {
         return "A version, tag, or new package name is required";
       }
 
       if (rename?.length > 0) {
         // A version isn't required when renaming a package (apparently)
-        if (version?.length <= 0) { version = "patch"; }
+        if (version?.length === 0) { version = "patch"; }
         originalName = pack.name;
 
         try {
@@ -479,7 +479,7 @@ have published it.\
       // Now we know a version has been specified, and that we have settled any
       // rename concerns. Lets get to publication
 
-      if (tag?.length <= 0) {
+      if (tag?.length === 0) {
         // only create and assign a tag if the user didn't specify one.
         // if they did we assume that tag already exists and only work to publish
         try {

--- a/src/publish.js
+++ b/src/publish.js
@@ -30,7 +30,6 @@ class Publish extends Command {
 Usage: ppm publish [<newversion> | major | minor | patch | build]
        ppm publish --tag <tagname>
        ppm publish --rename <new-name>
-       ppm publish --verbose
 
 Publish a new version of the package in the current working directory.
 
@@ -52,7 +51,6 @@ have published it.\
       );
       options.alias('h', 'help').describe('help', 'Print this usage message');
       options.alias('t', 'tag').string('tag').describe('tag', 'Specify a tag to publish. Must be of the form vx.y.z');
-      options.boolean('v').alias('v', 'verbose').describe('verbose', 'Log extra details during publication');
       return options.alias('r', 'rename').string('rename').describe('rename', 'Specify a new name for the package');
     }
 
@@ -421,7 +419,7 @@ have published it.\
     async run(options) {
       let pack, originalName;
       options = this.parseOptions(options.commandArgs);
-      let {tag, rename, verbose} = options.argv;
+      let {tag, rename} = options.argv;
       let [version] = options.argv._;
 
       // Normalize variables to ensure they are strings with zero length
@@ -435,11 +433,6 @@ have published it.\
       }
       if (typeof rename !== "string") {
         rename = "";
-      }
-
-      if (verbose) {
-        process.stdout.write("Attempting to publish package with the following options:");
-        process.stdout.write(JSON.stringify(options, null, 2));
       }
 
       try {


### PR DESCRIPTION
After numerous issues and reports and pain points of this publish logic, we hit a point after enabling strict versioning on the backend to discover that the original logic completely fails now.

I'll try to update this with more details with more time, but for now, here's an attempt that should resolve our woes.