### PR TITLE
Begin less reliance on `async` package: Await as we go

### DIFF
--- a/src/ci.js
+++ b/src/ci.js
@@ -72,7 +72,7 @@ but cannot be used to install new packages or dependencies.\
     try {
       this.npm = await config.loadNpm();
       await this.loadInstalledAtomMetadata();
-      this.installModules(opts);
+      await this.installModules(opts);
     } catch(err) {
       return err;
     }

--- a/src/ci.js
+++ b/src/ci.js
@@ -2,7 +2,6 @@
 const path = require('path');
 const fs = require('./fs');
 const yargs = require('yargs');
-const async = require('async');
 const _ = require('underscore-plus');
 
 const config = require('./apm');
@@ -70,17 +69,13 @@ but cannot be used to install new packages or dependencies.\
   async run(options) {
     const opts = this.parseOptions(options.commandArgs);
 
-    const commands = [];
-    commands.push(async () => {
-      const npm = await config.loadNpm();
-      this.npm = npm;
-    });
-    commands.push(async () => await this.loadInstalledAtomMetadata());
-    commands.push(async () => this.installModules(opts));
     try {
-      await async.waterfall(commands);
-    } catch (error) {
-      return error; // errors as return values atm
+      this.npm = await config.loadNpm();
+      await this.loadInstalledAtomMetadata();
+      this.installModules(opts);
+    } catch(err) {
+      return err;
     }
+
   }
 };

--- a/src/dedupe.js
+++ b/src/dedupe.js
@@ -1,7 +1,6 @@
 
 const path = require('path');
 
-const async = require('async');
 const _ = require('underscore-plus');
 const yargs = require('yargs');
 
@@ -76,13 +75,11 @@ This command is experimental.\
 
       this.createAtomDirectories();
 
-      const commands = [];
-      commands.push(async () => await this.loadInstalledAtomMetadata());
-      commands.push(async () => await this.dedupeModules(options));
       try {
-        await async.waterfall(commands);
-      } catch (error) {
-        return error; //errors as return values atm
+        await this.loadInstalledAtomMetadata();
+        await this.dedupeModules(options);
+      } catch(err) {
+        return err;
       }
     }
 }

--- a/src/develop.js
+++ b/src/develop.js
@@ -3,7 +3,6 @@ const fs = require('fs');
 const path = require('path');
 
 const _ = require('underscore-plus');
-const async = require('async');
 const yargs = require('yargs');
 
 const config = require('./apm');
@@ -64,7 +63,7 @@ cmd-shift-o to run the package out of the newly cloned repository.\
 
             return void reject(`No repository URL found for package: ${packageName}`);
           }
-          
+
           const message = request.getErrorMessage(body, error);
           return void reject(`Request for package information failed: ${message}`);
         });
@@ -90,7 +89,7 @@ cmd-shift-o to run the package out of the newly cloned repository.\
     installDependencies(packageDirectory, options) {
         process.chdir(packageDirectory);
         const installOptions = _.clone(options);
-  
+
         return new Install().run(installOptions);
     }
 
@@ -117,12 +116,10 @@ cmd-shift-o to run the package out of the newly cloned repository.\
 
       try {
         const repoUrl = await this.getRepositoryUrl(packageName);
-        const tasks = [];
-        tasks.push(async () => await this.cloneRepository(repoUrl, packageDirectory, options));
-        tasks.push(async () => await this.installDependencies(packageDirectory, options));
-        tasks.push(async () => await this.linkPackage(packageDirectory, options));
-
-        await async.waterfall(tasks);
+        
+        await this.cloneRepository(repoUrl, packageDirectory, options);
+        await this.installDependencies(packageDirectory, options);
+        await this.linkPackage(packageDirectory, options);
       } catch (error) {
         return error; //errors as return values atm
       }

--- a/src/install.js
+++ b/src/install.js
@@ -114,25 +114,24 @@ package names to install with optional versions using the
               return void resolve({name: undefined, installPath: undefined});
           }
 
+          const commands = [];
           const children = fs.readdirSync(nodeModulesDirectory)
             .filter(dir => dir !== ".bin");
           assert.equal(children.length, 1, "Expected there to only be one child in node_modules");
           const child = children[0];
           const source = path.join(nodeModulesDirectory, child);
           const destination = path.join(this.atomPackagesDirectory, child);
+          commands.push(async () => await fs.cp(source, destination));
+          commands.push(async () => await this.buildModuleCache(pack.name));
+          commands.push(async () => await this.warmCompileCache(pack.name));
 
-          try {
-            await fs.cp(source, destination);
-            await this.buildModuleCache(pack.name);
-            await this.warmCompileCache(pack.name);
-
+          async.waterfall(commands).then(() => {
             if (!options.argv.json) { this.logSuccess(); }
-            resolve({ name: child, installPath: destination });
-
-          } catch(err) {
+            resolve({name: child, installPath: destination});
+          }, error => {
             this.logFailure();
-            reject(err);
-          }
+            reject(error);
+          });
         });
       });
     }
@@ -389,9 +388,11 @@ Run ppm -v after installing Git to see what version has been detected.\
 
     async installDependencies(options) {
       options.installGlobally = false;
+      const commands = [];
+      commands.push(async () => void await this.installModules(options));
+      commands.push(async () => void await this.installPackageDependencies(options));
 
-      await this.installModule(options);
-      await this.installPackageDependencies(options);
+      await async.waterfall(commands);
     }
 
     // Get all package dependency names and versions from the package.json file.


### PR DESCRIPTION
Within this repo we use the `async` package nearly everywhere, which while it may have been a game changer when using CoffeeScript, I'd argue with current versions of JavaScript, this isn't really needed.

Although replacing it's usage isn't always straightforward.

So what I've done here is remove the straightforward sections, which mostly consists of [`async.waterfall()`](https://caolan.github.io/async/v3/docs.html#waterfall) which simply would run an array of async functions one after the other.

Due to this simplicity I was able to easily convert any instances of `async.waterfall()` to a few `await` calls wrapped in a `try...catch` block.

But I've otherwise left `async` usage in locations with more complex setups, that wouldn't be a simple translation to do. But eventually I'd hope to remove `async` as a package entirely