### PR TITLE
Fix incorrect behavior on package rename

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,11 +2,11 @@ module.exports = {
   env: {
     browser: false,
     commonjs: true,
-    es2021: true
+    es2021: true,
+    node: true
   },
   extends: [
     "eslint:recommended",
-    "plugin:node/recommended"
   ],
   overrides: [],
   parserOptions: {
@@ -18,8 +18,6 @@ module.exports = {
       asyncArrow: "always",
       named: "never"
     }],
-    "prettier/prettier": "off",
-    "ember-suave/lines-between-object-propertiess": "off",
     "no-empty": "off",
     "no-unused-vars": [ "error", {
       argsIgnorePattern: "^_"

--- a/src/publish.js
+++ b/src/publish.js
@@ -487,7 +487,10 @@ have published it.\
 
       let doesPackageExist;
       try {
-        doesPackageExist = await this.packageExists(pack.name);
+        // If `originalName` is defined, it means we're renaming this package.
+        // We must therefore check if the package's _old_ name exists, not its
+        // _new_ name.
+        doesPackageExist = await this.packageExists(originalName ?? pack.name);
       } catch(error) {
         return error;
       }


### PR DESCRIPTION
Suppose a user maintains a package called `old-name` and wants to rename it to `new-name`. When the user runs

```shell
ppm publish patch --rename new-name
```

`ppm` does these things (and other things, but these are the ones relevant to this discussion):

* automatically updates the `name` field in `package.json` to the new value (in fact, it will scold you if you try to do this manually); then
* asks the API whether the package already exists.
  * if so, it POSTs to `/api/packages/old-name/versions/` with the `package.json` metadata;
  * if not, it POSTs to `/api/packages/` with that same metadata (since this is a brand-new publish of a package).

If, in this scenario, the API got confused and told us that the package _didn't_ exist, we'd end up treating this rename task as the publishing of a brand-new package. `new-name` would get published, but the API would not understand that it had anything to do with `old-name`.

As you might've guessed, that's exactly what is happening. It's happening because we end up asking the API if `new-name` already exists, not `old-name`! This guarantees that `ppm publish [tag] --rename` won't ever work.

The fix is easy — since we already keep track of the original name, we'll ask the API whether the original name exists.

I've tested this fix locally to ensure it hits the proper code path. In my test, the server responded with an error, but we can sort that out later.

---

I wrote new specs for this behavior. I also took this opportunity to clean up this repo's `.eslintrc.js` file; it referenced several plugins that weren't even installed.