### PR TITLE
Report errors from backend when a request fails

### DIFF
--- a/src/develop.js
+++ b/src/develop.js
@@ -51,21 +51,16 @@ cmd-shift-o to run the package out of the newly cloned repository.\
         };
         return request.get(requestSettings, (error, response, body) => {
           body ??= {};
-          if (error != null) {
-            return void reject(`Request for package information failed: ${error.message}`);
+          if (error != null || response.statusCode !== 200) {
+            return void reject(`Request for package information failed: ${request.getErrorMessage(body, error)}`);
           }
 
-          if (response.statusCode === 200) {
-            const repositoryUrl = body.repository.url;
-            if (repositoryUrl) {
-              return void resolve(repositoryUrl);
-            }
-
+          const repositoryUrl = body.repository.url;
+          if (repositoryUrl) {
+            return void resolve(repositoryUrl);
+          } else {
             return void reject(`No repository URL found for package: ${packageName}`);
           }
-
-          const message = request.getErrorMessage(body, error);
-          return void reject(`Request for package information failed: ${message}`);
         });
       });
     }
@@ -116,7 +111,7 @@ cmd-shift-o to run the package out of the newly cloned repository.\
 
       try {
         const repoUrl = await this.getRepositoryUrl(packageName);
-        
+
         await this.cloneRepository(repoUrl, packageDirectory, options);
         await this.installDependencies(packageDirectory, options);
         await this.linkPackage(packageDirectory, options);

--- a/src/install.js
+++ b/src/install.js
@@ -217,16 +217,10 @@ Run ppm -v after installing Git to see what version has been detected.\
       };
       return new Promise((resolve, reject) => {
         request.get(requestSettings, (error, response, body) => {
-          let message;
           body ??= {};
-          if (error != null) {
-            message = `Request for package information failed: ${error.message}`;
-            if (error.status) { message += ` (${error.status})`; }
-            return void reject(message);
-          }
-          if (response.statusCode !== 200) {
-            message = request.getErrorMessage(body, error);
-            return void reject(`Request for package information failed: ${message}`);
+          if (error != null || response.statusCode !== 200) {
+            const message = request.getErrorMessage(body, error);
+            return void reject(`Request for package information failed: '${message}'`);
           }
           if (!body.releases.latest) {
             return void reject(`No releases available for ${packageName}`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -154,10 +154,10 @@ have published it.\
       return new Promise((resolve, reject) => {
         request.get(requestSettings, (error, response, body) => {
           body ??= {};
-          if (error != null || response.statusCode !== 200) {
+          if (error != null) {
             return void reject(request.getErrorMessage(body, error));
           }
-          resolve(true);
+          resolve(response.statusCode === 200);
         });
       });
     }

--- a/src/publish.js
+++ b/src/publish.js
@@ -154,10 +154,10 @@ have published it.\
       return new Promise((resolve, reject) => {
         request.get(requestSettings, (error, response, body) => {
           body ??= {};
-          if (error != null) {
-            return void reject(error);
+          if (error != null || response.statusCode !== 200) {
+            return void reject(request.getErrorMessage(body, error));
           }
-          resolve(response.statusCode === 200);
+          resolve(true);
         });
       });
     }
@@ -200,13 +200,10 @@ have published it.\
         return new Promise((resolve, reject) => {
           request.post(requestSettings, (error, response, body) => {
             body ??= {};
-            if (error != null) {
-              return void reject(error);
-            }
-            if (response.statusCode !== 201) {
+            if (error != null || response.statusCode !== 201) {
               const message = request.getErrorMessage(body, error);
               this.logFailure();
-              return void reject(`Registering package in ${repository} repository failed: ${message}`);
+              return void reject(`Registering package in ${repository} repository failed: '${message}'`);
             }
 
             this.logSuccess();
@@ -241,12 +238,9 @@ have published it.\
       return new Promise((resolve, reject) => {
         request.post(requestSettings, (error, response, body) => {
           body ??= {};
-          if (error != null) {
-            return void reject(error);
-          }
-          if (response.statusCode !== 201) {
+          if (error != null || response.statusCode !== 201) {
             const message = request.getErrorMessage(body, error);
-            return void reject(`Creating new version failed: ${message}`);
+            return void reject(`Creating new version failed: '${message}'`);
           }
 
           resolve();

--- a/src/request.js
+++ b/src/request.js
@@ -15,7 +15,7 @@ function loadNpm() {
     userconfig: config.getUserConfigPath(),
     globalconfig: config.getGlobalConfigPath()
   };
-  return new Promise((resolve, reject) => 
+  return new Promise((resolve, reject) =>
     void npm.load(npmOptions, (error, value) => void(error != null ? reject(error) : resolve(value)))
   );
 };
@@ -66,7 +66,7 @@ module.exports = {
           .ok((res) => OK_STATUS_CODES.includes(res.status));
         return void callback(null, res, res.body);
       } catch (error) {
-        return void callback(error, null, null); 
+        return void callback(error, null, null);
       }
     });
   },
@@ -141,7 +141,13 @@ module.exports = {
     if (err?.status === 503) {
       return `${err.response.req.host} is temporarily unavailable, please try again later.`;
     } else {
-      return err?.response?.body ?? err?.response?.error ?? err ?? body.message ?? body.error ?? body;
+      let msg = err?.response?.body?.message ?? err?.response?.body ?? err?.response?.error ?? err ?? body.message ?? body.error ?? body;
+      if (typeof msg === "object") {
+        // If we found a message that's still an object, lets make sure it'll
+        // still show up for users
+        msg = JSON.stringify(msg);
+      }
+      return msg;
     }
   },
 

--- a/src/search.js
+++ b/src/search.js
@@ -47,18 +47,15 @@ Search for packages/themes.\
       return new Promise((resolve, reject) => {
         request.get(requestSettings, function(error, response, body) {
           body ??= {};
-          if (error != null) {
-            return void reject(error);
+          if (error != null || response.statusCode !== 200) {
+            const message = request.getErrorMessage(body, error);
+            return void reject(`Searching packages failed: '${message}'`);
           }
-          if (response.statusCode === 200) {
-            let packages = body.filter(pack => (pack.releases != null ? pack.releases.latest : undefined) != null);
-            packages = packages.map(({readme, metadata, downloads, stargazers_count}) => _.extend({}, metadata, {readme, downloads, stargazers_count}));
-            packages = packages.filter(({name, version}) => !isDeprecatedPackage(name, version));
-            return void resolve(packages);
-          }
-
-          const message = request.getErrorMessage(body, error);
-          reject(`Searching packages failed: ${message}`);
+          
+          let packages = body.filter(pack => (pack.releases != null ? pack.releases.latest : undefined) != null);
+          packages = packages.map(({readme, metadata, downloads, stargazers_count}) => _.extend({}, metadata, {readme, downloads, stargazers_count}));
+          packages = packages.filter(({name, version}) => !isDeprecatedPackage(name, version));
+          return void resolve(packages);
         });
       });
     }

--- a/src/star.js
+++ b/src/star.js
@@ -48,18 +48,14 @@ Run \`ppm stars\` to see all your starred packages.\
       return new Promise((resolve, reject) => {
         request.post(requestSettings, (error, response, body) => {
           body ??= {};
-          if (error != null) {
-            this.logFailure();
-            return void reject(error);
-          }
           if ((response.statusCode === 404) && ignoreUnpublishedPackages) {
             process.stdout.write('skipped (not published)\n'.yellow);
             return void reject();
           }
-          if (response.statusCode !== 200) {
+          if (error != null || response.statusCode !== 200) {
             this.logFailure();
             const message = request.getErrorMessage(body, error);
-            return void reject(`Starring package failed: ${message}`);
+            return void reject(`Starring package failed: '${message}'`);
           }
 
           this.logSuccess();

--- a/src/unpublish.js
+++ b/src/unpublish.js
@@ -52,14 +52,10 @@ name is specified.\
         return new Promise((resolve, reject) =>{
           request.del(options, (error, response, body) => {
             body ??= {};
-            if (error != null) {
+            if (error != null || response.statusCode !== 204) {
               this.logFailure();
-              return void reject(error);
-            }
-            if (response.statusCode !== 204) {
-              this.logFailure();
-              const message = body.message ?? body.error ?? body;
-              return void reject(`Unpublishing failed: ${message}`);
+              const message = request.getErrorMessage(body, error);
+              return void reject(`Unpublishing failed: '${message}'`);
             }
 
             this.logSuccess();

--- a/src/unstar.js
+++ b/src/unstar.js
@@ -38,14 +38,10 @@ Run \`ppm stars\` to see all your starred packages.\
       return new Promise((resolve, reject) => {
         request.del(requestSettings, (error, response, body) => {
           body ??= {};
-          if (error != null) {
-            this.logFailure();
-            return void reject(error);
-          }
-          if (response.statusCode !== 204) {
+          if (error != null || response.statusCode !== 204) {
             this.logFailure();
             const message = request.getErrorMessage(body, error);
-            return void reject(`Unstarring package failed: ${message}`);
+            return void reject(`Unstarring package failed: '${message}'`);
           }
 
           this.logSuccess();

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -102,15 +102,12 @@ available updates.\
       return new Promise((resolve, reject) => {
         request.get(requestSettings, (error, response, body) => {
           body ??= {};
-          if (error != null) {
-            return void reject(`Request for package information failed: ${error.message}`);
-          }
-          if (response.statusCode === 404) {
+          if (response.statusCode === 404 && error == null) {
             return void resolve();
           }
-          if (response.statusCode !== 200) {
-            const message = body.message ?? body.error ?? body;
-            return void reject(`Request for package information failed: ${message}`);
+          if (error != null || response.statusCode !== 200) {
+            const message = request.getErrorMessage(body, error);
+            return void reject(`Request for package information failed: '${message}'`);
           }
 
           const atomVersion = this.installedAtomVersion;

--- a/src/view.js
+++ b/src/view.js
@@ -76,12 +76,9 @@ View information about a package/theme.\
       return new Promise((resolve, reject) => {
         request.get(requestSettings, (error, response, body) => {
           body ??= {};
-          if (error != null) {
-            return void reject(error);
-          }
-          if (response.statusCode !== 200) {
-            const message = body.message ?? body.error ?? body;
-            return void reject(`Requesting package failed: ${message}`);
+          if (error != null || response.statusCode !== 200) {
+            const message = request.getErrorMessage(body, error);
+            return void reject(`Requesting package failed: '${message}'`);
           }
 
           this.getLatestCompatibleVersion(body, options).then(version => {


### PR DESCRIPTION
As many of you already know, often times a user reports an issue with the backend, stating they have no helpful error message to go off of. Just receiving `Internal Server Error`.

We had always assumed that this was a failing of the backend, that errors weren't being created there that can help the user. While in some cases this is true, over time I have continued to add more and more intelligent error messages, and written tests to confirm this gets back to the user.

That is until I finally put this to the test and realized that PPM itself is at fault for eating our helpful error messages.

Basically when a request is made via `request.js` it can error when the returned status code is not `200, 201, 204, 404`, which we expect, but oftentimes when the request fails, the rest of PPM ends that interaction like `return void reject(error);` which asks `superagent` what the error was, which is only ever generated based off the HTTP status code returned, such as `500 = Internal Server Error`.

That's why we see it so often, when a request on the backend errors out it returns the `500` HTTP Status Code, along with helpful information in the returned JSON, but `superagent` doesn't look there when asked to return an error to the rest of PPM.

So what I've done is in this PR, is that whenever a request using our backend fails, we always call `request.getErrorMessage()` which will either find an error from the backend if it exists, or will get an error message from `superagent` if needed. This way we get the best of both worlds.

With this changes made, I've turned this test command output:

```
Preparing and tagging a new version done
Pushing v1.6.0 tag done
Publishing autocomplete-powershell-winserver2022@v1.6.0 failed
Internal Server Error
```

Into the new output (using the error returned directly by the backend:

```
Preparing and tagging a new version done
Pushing v1.16.0 tag done
Publishing autocomplete-powershell-winserver2022@v1.16.0 failed
Creating new version failed: 'Server Error: From Bad Repo: Failed to get repo: onfused-Techie/autocomplete-powershell-winserver2022 - Server Error'
```

In this new output, oftentimes the user would now be able to see where they messed up and resolve the issue on their own, or if they cannot once provided to us, each section of the error message has meaning to where we may be able to tell the user exactly what went wrong.

Such as in this example case:
* `Server Error`: The status the backend is returning for the request
* `From Bad Repo`: The sub-error that caused the status to be returned, `bad-repo` meaning something about the package's data being incorrect or malformed. Either in the backend itself, or in the `package.json` on GitHub.
* `Failed to get repo`: The backend failed to get the repo's details from GitHub. 
* `onfused-Techie/autocomplete-powershell-winserver2022`: The repo the backend attempted to get
* `Server Error`: The status the backend got when attempting to get the repo.

With just this error message we know that the backend attempted to use package data, to get details of that package from GitHub. But the package string here resulting in GitHub returning a `server-error` status code. And since this was a version publish we know that the backend already has the package name, meaning the data is malformed on the backend and must be repaired by a database admin. (Keep in mind I purposefully mangled the data of my package for testing purposes)

But hopefully with this example above, it's obvious how much more helpful getting proper error messages into PPM will be, for users and for us.