### PR TITLE
Remove hard-coded architecture on Mac

### DIFF
--- a/src/apm.js
+++ b/src/apm.js
@@ -95,12 +95,7 @@ module.exports = {
   },
 
   getElectronArch() {
-    switch (process.platform) {
-      case 'darwin':
-        return 'x64';
-      default:
-        return process.env.ATOM_ARCH ?? process.arch;
-    }
+    return process.env.ATOM_ARCH ?? process.arch;
   },
 
   getUserConfigPath() {


### PR DESCRIPTION
Fixes #126.

We've known for a while about an issue where `ppm rebuild` fails to work properly on Apple Silicon. That command is run whenever a native module needs to be recompiled — either for a new processor architecture or for a new version of Electron — and there's even a GUI for it.

This is what it might look like for an end user, as it did for me last week when I got a new M3 MacBook Pro:

https://github.com/user-attachments/assets/77b27b32-2937-4b61-a82e-bba419c08993

The built-in `update-package-dependencies` package is a frontend to `ppm rebuild`. Notice how it doesn't say “failed to rebuild the package”; it thinks it's succeeded, and yet after a window reload it once again flags the native module as being for the wrong architecture.

This was on my radar because some of `pulsar-ide-python`’s users had complained about it. `zadeh` was used in `atom-languageclient` — I moved away from it in my `@savetheclocktower/atom-languageclient` fork in order to work around this issue — so it affected a number of packages. It was strange to learn, then, that [`npm rebuild` seemed not to be susceptible to this issue](https://github.com/pulsar-edit/ppm/issues/126#issuecomment-1960101764). This reduced it to an exercise in finding out exactly what the discrepancy was between `ppm rebuild` and `npm rebuild`.

For a few hours I was certain it was some sort of artifact of a too-old version of Node, NPM, or `node-gyp`. I noticed a behavior difference between two of my local versions of Node — `14.16.0` did the wrong thing, whereas `16.19.0` did the right thing — and I generally wasted my own time until I looked closely enough at the logging and traced the issue back to the PPM source itself.

PPM provides a bunch of build flags for NPM, processor architecture among them; on `darwin` it's been hard-coding `x64` for [years and years and years](https://github.com/pulsar-edit/ppm/commit/7d923b2d0b2997056d60409814c3cde05413480b). I don't know why, but it was implemented in such a way that you couldn't even override it with an environment variable.

Removing the hard-coded special case seems to fix it for me. We should ensure it works as expected on an Intel Mac, but this feels like the obvious obvious obvious fix. I'm glad that it's as simple as this, though somewhat annoyed that I didn't notice it earlier.

Since neither `ppm rebuild` nor `npm rebuild` seems to need a subsequent pass through `electron-rebuild`, this should fix #126 altogether. ~~(This might even make it so that (e.g.) `ppm install autocomplete-paths` installs the package properly the first time around; I'll check that next.)~~ (Yeah, seems to work.)

I hope we can get this into the next release as a quality-of-life issue, but it can wait a month if people are nervous about it.