### PR TITLE
Remove dependency on "request" package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "open": "7.3.0",
     "plist": "3",
     "read": "~1.0.7",
-    "request": "^2.88.2",
     "season": "^6.0.2",
     "second-mate": "https://github.com/pulsar-edit/second-mate.git#9686771",
     "semver": "^7.3.4",

--- a/script/download-node.js
+++ b/script/download-node.js
@@ -6,7 +6,7 @@ const path = require('path');
 const tar = require('tar');
 const temp = require('temp');
 
-const request = require('request');
+const superagent = require('superagent');
 const getInstallNodeVersion = require('./bundled-node-version')
 
 temp.track();
@@ -23,14 +23,15 @@ const downloadFileToLocation = function(url, filename, callback) {
   const stream = fs.createWriteStream(filename);
   stream.on('end', callback);
   stream.on('error', callback);
-  const requestStream = request.get(url)
-  requestStream.on('response', function(response) {
-    if (response.statusCode === 404) {
+  superagent
+    .get(url)
+    .on('response', response => {
+      if (response.statusCode === 404) {
       console.error('download not found:', url);
       process.exit(1);
-    }
-    requestStream.pipe(stream);
-  });
+      }
+    })
+    .pipe(stream);
 };
 
 const downloadTarballAndExtract = function(url, location, callback) {
@@ -42,14 +43,15 @@ const downloadTarballAndExtract = function(url, location, callback) {
     callback.call(this, tempPath);
   });
   stream.on('error', callback);
-  const requestStream = request.get(url)
-  requestStream.on('response', function(response) {
-    if (response.statusCode === 404) {
-      console.error('download not found:', url);
-      process.exit(1);
-    }
-    requestStream.pipe(zlib.createGunzip()).pipe(stream);
-  });
+  superagent
+    .get(url)
+    .on('response', response => {
+      if (response.statusCode === 404) {
+        console.error('download not found:', url);
+        process.exit(1);
+      }
+    })
+    .pipe(zlib.createGunzip()).pipe(stream);
 };
 
 const copyNodeBinToLocation = function(callback, version, targetFilename, fromDirectory) {

--- a/script/download-node.js
+++ b/script/download-node.js
@@ -27,8 +27,8 @@ const downloadFileToLocation = function(url, filename, callback) {
     .get(url)
     .on('response', response => {
       if (response.statusCode === 404) {
-      console.error('download not found:', url);
-      process.exit(1);
+        console.error('download not found:', url);
+        process.exit(1);
       }
     })
     .pipe(stream);


### PR DESCRIPTION
It was only used in the download-node script - now that also uses superagent instead.

I tested the download locally and it did succeed.