### PR TITLE
Update to read v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "npm": "https://github.com/pulsar-edit/npm-cli/releases/download/v6.14.19-pulsar2/npm-6.14.19-pulsar2.tgz",
     "open": "7.3.0",
     "plist": "3",
-    "read": "~1.0.7",
+    "read": "^3",
     "season": "^6.0.2",
     "second-mate": "https://github.com/pulsar-edit/second-mate.git#9686771",
     "semver": "^7.3.4",

--- a/src/login.js
+++ b/src/login.js
@@ -1,6 +1,6 @@
 
 const yargs = require('yargs');
-const read = require('read');
+const { read } = require('read');
 const open = require('open');
 
 const auth = require('./auth');
@@ -54,13 +54,7 @@ be used to identify you when publishing packages.\
     }
 
     prompt(options) {
-      return new Promise((resolve, reject) =>
-        void read(options, (error, answer) =>
-          error != null
-          ? void reject(error)
-          : void resolve(answer)
-        )
-      );
+      return read(options);
     }
 
     async welcomeMessage() {

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const async = require('async');
 const yargs = require('yargs');
-const read = require('read');
+const { read } = require('read');
 const semver = require('semver');
 const Git = require('git-utils');
 
@@ -175,16 +175,10 @@ available updates.\
       return updates;
     }
 
-    promptForConfirmation() {
-      return new Promise((resolve, reject) => {
-        read({prompt: 'Would you like to install these updates? (yes)', edit: true}, (error, answer) => {
-          if (error != null) {
-            return void reject(error);
-          }
-          answer = answer ? answer.trim().toLowerCase() : 'yes';
-          resolve((answer === 'y') || (answer === 'yes'));
-        });
-      });
+    async promptForConfirmation() {
+      let answer = await read({prompt: 'Would you like to install these updates? (yes)', edit: true});
+      answer = answer ? answer.trim().toLowerCase() : 'yes';
+      return ['y', 'yes'].includes(answer);
     }
 
     async installUpdates(updates) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3186,6 +3186,11 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+mute-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
+  integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
+
 mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
@@ -4135,6 +4140,13 @@ read@1, read@~1.0.1, read@~1.0.7:
   integrity sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==
   dependencies:
     mute-stream "~0.0.4"
+
+read@^3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/read/-/read-3.0.1.tgz#926808f0f7c83fa95f1ef33c0e2c09dbb28fd192"
+  integrity sha512-SLBrDU/Srs/9EoWhU5GdbAoxG1GzpQHo/6qiGItaoLJ1thmYpcNIM1qISEUvyHBzfGlWIyd6p2DNi1oV1VmAuw==
+  dependencies:
+    mute-stream "^1.0.0"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"


### PR DESCRIPTION
Read v4 declares a dependency on Node v18 at least and the bundled Node version is v16.0.0 still. The modifications aren't big but that upgrade would be the way even further. Other than that, this package didn't change a lot. It's supposed to "just work" if one exports the `read` function appropriately (not as a "default" import), with an async interface that we pretty much already had because of the promptX kind of methods.