### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-14
           - windows-latest
         node_version:
           - 14


### PR DESCRIPTION
See commit messages for details.

Makes CI pass.

> [CI: Update from windows-2019 to windows-latest](https://github.com/pulsar-edit/ppm/commit/e36c84a7d8e6a3ee4669a251bac0c3bb49ee53d2)
> 
> windows-2019 images are discontinued, switch to '-latest'.
---
> [CI: Update node-gyp on Windows Node v14 jobs](https://github.com/pulsar-edit/ppm/commit/87d22be4f0d77c673618bc3024f4fdb1f59a330b)
> 
> Need newer node-gyp to support newer Visual Studio versions.
> 
> (Node-gyp 9 is the newest node-gyp that is compatible with NodeJS 14. It's new enough to support the Visual Studio version used in CI, though.)
---
> [CI: Pin macOS runner image to macos-14](https://github.com/pulsar-edit/ppm/commit/2ba5db424454d5bd8732c859375aefaa6aa6144a)
> 
> macos-latest resolves to macos-15, which is too new to work with one of our dependencies. Specifically: there are compilation errors in git-utils --> libgit2 --> zlib when compiling with too new of an Xcode toolchain, apparently.
> 
> So, pin to the macos-14 image, which still works with our dependencies.