### PR TITLE
Fix misnamed variable in `rebuild` command

### DIFF
--- a/src/rebuild.js
+++ b/src/rebuild.js
@@ -52,7 +52,7 @@ All the modules will be rebuilt if no module names are specified.\
       return new Promise((resolve, reject) =>
         void this.fork(this.atomNpmPath, rebuildArgs, {env}, (code, stderr) => {
           if (code !== 0) {
-            reject(stderr ?? `Unknown error: code ${code}`);
+            reject(stderr ?? `Unknown error while invoking npm: code ${code}`);
             return;
           }
 


### PR DESCRIPTION
This is a fix for [the bug I described here](https://github.com/pulsar-edit/pulsar/pull/1367#issuecomment-3479172584). This is an artifact of an earlier rewrite and updated exception handling; `stderr` now exists in another scope and is thrown, so we should catch it and treat `error` like a string.

I also noticed that, when `stderr` is empty, we just reject with an empty string in `forkNpmRebuild`. In that case, I figure a generic message with the failure code is better than an empty string, so I changed it. Happy to take that out if it bothers anyone.

I've not made much progress in figuring out [how to hit this particular code path on demand](https://github.com/pulsar-edit/pulsar/pull/1367#issuecomment-3479415089), though! If I find a way, I'll update the PR.