### PR TITLE
Eliminate mv, ncp, wrench dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "git-utils": "^5.7.2",
     "hosted-git-info": "^3.0.7",
     "keytar": "^7.7.0",
-    "mv": "2.1.1",
-    "ncp": "~2.0.0",
     "npm": "https://github.com/pulsar-edit/npm-cli/releases/download/v6.14.19-pulsar2/npm-6.14.19-pulsar2.tgz",
     "open": "7.3.0",
     "plist": "3",
@@ -44,7 +42,6 @@
     "temp": "^0.9.4",
     "underscore-plus": "1.x",
     "wordwrap": "1.0.0",
-    "wrench": "~1.5.1",
     "yargs": "^3.32.0"
   },
   "devDependencies": {

--- a/spec/ci-spec.js
+++ b/spec/ci-spec.js
@@ -1,9 +1,9 @@
 const path = require('path');
 const fs = require('fs');
+const fsPromises = require('fs/promises');
 const http = require('http');
 const temp = require('temp');
 const express = require('express');
-const wrench = require('wrench');
 const CSON = require('season');
 const apm = require('../src/apm-cli');
 const { nodeVersion } = JSON.parse(fs.readFileSync(path.join(__dirname,'config.json')));
@@ -123,7 +123,7 @@ describe('apm ci', () => {
 
   it('installs dependency versions as specified by the lockfile', async () => {
     const moduleDirectory = path.join(temp.mkdirSync('apm-test-'), 'test-module-with-lockfile');
-    wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'test-module-with-lockfile'), moduleDirectory);
+    await fsPromises.cp(path.join(__dirname, 'fixtures', 'test-module-with-lockfile'), moduleDirectory, { recursive: true });
     process.chdir(moduleDirectory);
     const callback = jasmine.createSpy('callback');
     await apmRun(['ci'], callback);
@@ -136,7 +136,7 @@ describe('apm ci', () => {
 
   it('builds a native dependency correctly', async () => {
     const moduleDirectory = path.join(temp.mkdirSync('apm-test-'), 'test-module-with-native');
-    wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'test-module-with-lockfile'), moduleDirectory);
+    await fsPromises.cp(path.join(__dirname, 'fixtures', 'test-module-with-lockfile'), moduleDirectory, { recursive: true });
     process.chdir(moduleDirectory);
     const pjsonPath = path.join(moduleDirectory, 'package.json');
     const pjson = CSON.readFileSync(pjsonPath);
@@ -160,7 +160,7 @@ describe('apm ci', () => {
 
   it('fails if the lockfile is not present', async () => {
     const moduleDirectory = path.join(temp.mkdirSync('apm-test-'), 'test-module');
-    wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'test-module'), moduleDirectory);
+    await fsPromises.cp(path.join(__dirname, 'fixtures', 'test-module'), moduleDirectory, { recursive: true });
     process.chdir(moduleDirectory);
 
     const callback = jasmine.createSpy('callback');
@@ -171,7 +171,7 @@ describe('apm ci', () => {
 
   it('fails if the lockfile is out of date', async () => {
     const moduleDirectory = path.join(temp.mkdirSync('apm-test-'), 'test-module-with-lockfile');
-    wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'test-module-with-lockfile'), moduleDirectory);
+    await fsPromises.cp(path.join(__dirname, 'fixtures', 'test-module-with-lockfile'), moduleDirectory, { recursive: true });
     process.chdir(moduleDirectory);
     const pjsonPath = path.join(moduleDirectory, 'package.json');
     const pjson = CSON.readFileSync(pjsonPath);

--- a/spec/clean-spec.js
+++ b/spec/clean-spec.js
@@ -1,9 +1,9 @@
 const path = require('path');
 const fs = require('fs-plus');
+const fsPromises = require('fs/promises');
 const temp = require('temp');
 const express = require('express');
 const http = require('http');
-const wrench = require('wrench');
 const apm = require('../src/apm-cli');
 const { nodeVersion } = JSON.parse(fs.readFileSync(path.join(__dirname, 'config.json')));
 
@@ -66,14 +66,14 @@ describe('apm clean', () => {
     );
     server = http.createServer(app);
     await new Promise((resolve) => {
-      server.listen(3000, '127.0.0.1', () => {
+      server.listen(3000, '127.0.0.1', async () => {
         console.log('Server started');
         process.env.ATOM_HOME = temp.mkdirSync('apm-home-dir-');
         process.env.ATOM_ELECTRON_URL = 'http://localhost:3000/node';
         process.env.ATOM_ELECTRON_VERSION = nodeVersion;
         process.env.npm_config_registry = 'http://localhost:3000/';
         moduleDirectory = path.join(temp.mkdirSync('apm-test-module-'), 'test-module-with-dependencies');
-        wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'test-module-with-dependencies'), moduleDirectory);
+        await fsPromises.cp(path.join(__dirname, 'fixtures', 'test-module-with-dependencies'), moduleDirectory, { recursive: true });
         process.chdir(moduleDirectory);
         resolve();
       });

--- a/spec/disable-spec.js
+++ b/spec/disable-spec.js
@@ -1,5 +1,5 @@
 const fs = require('fs-plus');
-const wrench = require('wrench');
+const fsPromises = require('fs/promises');
 const path = require('path');
 const temp = require('temp');
 const CSON = require('season');
@@ -26,17 +26,20 @@ describe('apm disable', () => {
     const packagesPath = path.join(atomHome, 'packages');
     const packageSrcPath = path.join(__dirname, 'fixtures');
     fs.makeTreeSync(packagesPath);
-    wrench.copyDirSyncRecursive(
+    await fsPromises.cp(
       path.join(packageSrcPath, 'test-module'),
-      path.join(packagesPath, 'test-module')
+      path.join(packagesPath, 'test-module'),
+      { recursive: true }
     );
-    wrench.copyDirSyncRecursive(
+    await fsPromises.cp(
       path.join(packageSrcPath, 'test-module-two'),
-      path.join(packagesPath, 'test-module-two')
+      path.join(packagesPath, 'test-module-two'),
+      { recursive: true }
     );
-    wrench.copyDirSyncRecursive(
+    await fsPromises.cp(
       path.join(packageSrcPath, 'test-module-three'),
-      path.join(packagesPath, 'test-module-three')
+      path.join(packagesPath, 'test-module-three'),
+      { recursive: true }
     );
 
     await apmRun(['disable', 'test-module-two', 'not-installed', 'test-module-three']);

--- a/spec/install-spec.js
+++ b/spec/install-spec.js
@@ -1,10 +1,10 @@
 const path = require('path');
 const CSON = require('season');
 const fs = require('../src/fs');
+const fsPromises = require('fs/promises');
 const temp = require('temp');
 const express = require('express');
 const http = require('http');
-const wrench = require('wrench');
 const Install = require('../src/install');
 const { nodeVersion } = JSON.parse(fs.readFileSync(path.join(__dirname,'config.json')));
 
@@ -279,7 +279,7 @@ describe('apm install', () => {
     describe('when no path is specified', () => {
       it('installs all dependent modules', async () => {
         const moduleDirectory = path.join(temp.mkdirSync('apm-test-module-'), 'test-module-with-dependencies');
-        wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'test-module-with-dependencies'), moduleDirectory);
+        await fsPromises.cp(path.join(__dirname, 'fixtures', 'test-module-with-dependencies'), moduleDirectory, { recursive: true });
         process.chdir(moduleDirectory);
         const callback = jasmine.createSpy('callback');
         await apmRun(['install'], callback);
@@ -367,9 +367,10 @@ describe('apm install', () => {
         });
         const packageDirectory = path.join(atomRepoPath, 'packages', 'test-module-with-dependencies');
         fs.makeTreeSync(path.join(atomRepoPath, 'packages'));
-        wrench.copyDirSyncRecursive(
+        await fsPromises.cp(
           path.join(__dirname, 'fixtures', 'test-module-with-dependencies'),
-          packageDirectory
+          packageDirectory,
+          { recursive: true }
         );
         const originalPath = process.cwd();
         process.chdir(atomRepoPath);

--- a/spec/list-spec.js
+++ b/spec/list-spec.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs-plus');
+const fsPromises = require('fs/promises');
 const temp = require('temp');
-const wrench = require('wrench');
 const CSON = require('season');
 
 async function listPackages (...args) {
@@ -116,12 +116,13 @@ describe('apm list', () => {
   }); // ensure invalid packages aren't listed
 
   describe('enabling and disabling packages', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const packagesPath = path.join(atomHome, 'packages');
       fs.makeTreeSync(packagesPath);
-      wrench.copyDirSyncRecursive(
+      await fsPromises.cp(
         path.join(__dirname, 'fixtures', 'test-module'),
-        path.join(packagesPath, 'test-module')
+        path.join(packagesPath, 'test-module'),
+        { recursive: true }
       );
       const configPath = path.join(atomHome, 'config.cson');
       CSON.writeFileSync(configPath, {

--- a/src/fs.js
+++ b/src/fs.js
@@ -1,8 +1,6 @@
 
 const fs = require('fs-plus');
 const fsPromises = require("fs/promises");
-const ncp = require('ncp');
-const wrench = require('wrench');
 const path = require('path');
 
 const fsAdditions = {
@@ -19,7 +17,7 @@ const fsAdditions = {
   },
 
   listRecursive(directoryPath) {
-    return wrench.readdirSyncRecursive(directoryPath);
+    return fsPromises.readdir(directoryPath, { recursive: true });
   },
 
   async cp(sourcePath, destinationPath) {

--- a/src/fs.js
+++ b/src/fs.js
@@ -22,25 +22,15 @@ const fsAdditions = {
     return wrench.readdirSyncRecursive(directoryPath);
   },
 
-  cp(sourcePath, destinationPath) {
-    return new Promise((resolve, reject) => {
-      fsPromises.rm(destinationPath, { recursive: true, force: true }).then(() => {
-        ncp(sourcePath, destinationPath, (error, value) => void (error != null ? reject(error) : resolve(value)));
-      }).catch((error) => {
-        return reject(error);
-      });
-    });
+  async cp(sourcePath, destinationPath) {
+    await fsPromises.rm(destinationPath, { recursive: true, force: true });
+    await fsPromises.cp(sourcePath, destinationPath, { recursive: true, verbatimSymlinks: true });
   },
 
-  mv(sourcePath, destinationPath) {
-    return new Promise((resolve, reject) => {
-      fsPromises.rm(destinationPath, { recursive: true, force: true }).then(() => {
-        wrench.mkdirSyncRecursive(path.dirname(destinationPath), 0o755);
-        fs.rename(sourcePath, destinationPath, (error, value) => void (error != null ? reject(error) : resolve(value)));
-      }).catch((error) => {
-        return reject(error);
-      });
-    });
+  async mv(sourcePath, destinationPath) {
+    await fsPromises.rm(destinationPath, { recursive: true, force: true });
+    await fsPromises.mkdir(path.dirname(destinationPath), { mode: 0o755, recursive: true });
+    await fsPromises.rename(sourcePath, destinationPath);
   }
 };
 

--- a/src/init.js
+++ b/src/init.js
@@ -68,7 +68,7 @@ on the option selected.\
           return `You must specify one of ${this.supportedSyntaxes.join(', ')} after the --syntax argument`;
         }
         templatePath = this.getTemplatePath(options.argv, `package-${syntax}`);
-        this.generateFromTemplate(packagePath, templatePath);
+        await this.generateFromTemplate(packagePath, templatePath);
         return;
       }
       if (options.argv.theme?.length > 0) {
@@ -78,7 +78,7 @@ on the option selected.\
         }
         const themePath = path.resolve(options.argv.theme);
         templatePath = this.getTemplatePath(options.argv, 'theme');
-        this.generateFromTemplate(themePath, templatePath);
+        await this.generateFromTemplate(themePath, templatePath);
         return;
       }
       if (options.argv.language?.length > 0) {
@@ -86,7 +86,7 @@ on the option selected.\
         const languageName = path.basename(languagePath).replace(/^language-/, '');
         languagePath = path.join(path.dirname(languagePath), `language-${languageName}`);
         templatePath = this.getTemplatePath(options.argv, 'language');
-        this.generateFromTemplate(languagePath, templatePath, languageName);
+        await this.generateFromTemplate(languagePath, templatePath, languageName);
         return;
       }
       // If we get this far, something about this command was invalid.
@@ -112,7 +112,7 @@ on the option selected.\
       await converter.convert();
       destinationPath = path.resolve(destinationPath);
       const templatePath = path.resolve(__dirname, '..', 'templates', 'bundle');
-      this.generateFromTemplate(destinationPath, templatePath);
+      await this.generateFromTemplate(destinationPath, templatePath);
     }
 
     async convertTheme(sourcePath, destinationPath) {
@@ -125,18 +125,18 @@ on the option selected.\
       await converter.convert();
       destinationPath = path.resolve(destinationPath);
       const templatePath = path.resolve(__dirname, '..', 'templates', 'theme');
-      this.generateFromTemplate(destinationPath, templatePath);
+      await this.generateFromTemplate(destinationPath, templatePath);
       fs.removeSync(path.join(destinationPath, 'styles', 'colors.less'));
       fs.removeSync(path.join(destinationPath, 'LICENSE.md'));
     }
 
-    generateFromTemplate(packagePath, templatePath, packageName) {
+    async generateFromTemplate(packagePath, templatePath, packageName) {
       packageName ??= path.basename(packagePath);
       const packageAuthor = process.env.GITHUB_USER || 'atom';
 
       fs.makeTreeSync(packagePath);
 
-      for (let childPath of Array.from(fs.listRecursive(templatePath))) {
+      for (let childPath of Array.from(await fs.listRecursive(templatePath))) {
         const templateChildPath = path.resolve(templatePath, childPath);
         let relativePath = templateChildPath.replace(templatePath, "");
         relativePath = relativePath.replace(/^\//, '');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,7 +1851,7 @@ glob@^10.3.10:
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
 
-glob@^6.0.1, glob@^6.0.4:
+glob@^6.0.4:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
   integrity sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==
@@ -3032,7 +3032,7 @@ mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.6, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.6, mkdirp@~0.5.0:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -3095,15 +3095,6 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-mv@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
-  integrity sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==
-  dependencies:
-    mkdirp "~0.5.1"
-    ncp "~2.0.0"
-    rimraf "~2.4.0"
-
 nan@^2.14.2:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
@@ -3113,11 +3104,6 @@ napi-build-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
   integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
-
-ncp@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
-  integrity sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==
 
 negotiator@0.6.3, negotiator@^0.6.3:
   version "0.6.3"
@@ -4199,13 +4185,6 @@ rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3, rimra
   dependencies:
     glob "^7.1.3"
 
-rimraf@~2.4.0:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
-  integrity sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==
-  dependencies:
-    glob "^6.0.1"
-
 rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
@@ -4591,8 +4570,7 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4609,6 +4587,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
@@ -4678,8 +4665,7 @@ stringify-package@^1.0.0, stringify-package@^1.0.1:
   resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4706,6 +4692,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -5203,11 +5196,6 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
-
-wrench@~1.5.1:
-  version "1.5.9"
-  resolved "https://registry.yarnpkg.com/wrench/-/wrench-1.5.9.tgz#411691c63a9b2531b1700267279bdeca23b2142a"
-  integrity sha512-QH+8W9n0UGDAxnRDOkQzG1N277GTaBgMDNdckluqnAY773njfs1gfo867IbMMbGjOZZof+zlRIUeQ9XN8VUHUQ==
 
 write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.3:
   version "2.4.3"


### PR DESCRIPTION
Resolves #157. Comments might be worth reading.

This is meant to be a simple and incremental refactor with relatively meaningful commits. All spectests pass after the modifications, and 3 direct dependencies have been eliminated in favor of Node's built-in `fs/promises` API.

As I mentioned before, `fsPromises.cp` is an experimental utility in Node 20 - however, I see no reason to come up with an intermediary solution when Node 20 itself is basically "oldstable" now and Node 22 promoted the same API to stable. I wouldn't expect any sort of trouble but in any case, this clearly seems to be a straight path.