### PR TITLE
Fix publishing for packages with git+ protocol repository URLs

### DIFF
--- a/spec/packages-spec.js
+++ b/spec/packages-spec.js
@@ -1,5 +1,44 @@
 const Packages = require('../src/packages');
 
+describe('getRepository', () => {
+  it('returns null for missing metadata', () => {
+    expect(Packages.getRepository()).toBeNull();
+    expect(Packages.getRepository({})).toBeNull();
+  });
+
+  it('parses repository.url with https protocol', () => {
+    const pack = {
+      repository: {
+        type: 'git',
+        url: 'https://github.com/pulsar-edit/ppm.git'
+      }
+    };
+    expect(Packages.getRepository(pack)).toEqual('pulsar-edit/ppm');
+  });
+
+  it('parses repository string', () => {
+    const pack = {
+      repository: 'https://github.com/pulsar-edit/ppm'
+    };
+    expect(Packages.getRepository(pack)).toEqual('pulsar-edit/ppm');
+  });
+
+  it('parses repository.url with git+https protocol', () => {
+    const pack = {
+      repository: {
+        type: 'git',
+        url: 'git+https://github.com/pulsar-edit/ppm.git'
+      }
+    };
+    expect(Packages.getRepository(pack)).toEqual('pulsar-edit/ppm');
+  });
+
+  it('returns null for invalid URLs', () => {
+    const pack = { repository: 'not-a-url' };
+    expect(Packages.getRepository(pack)).toBeNull();
+  });
+});
+
 describe('getRemote', () => {
   it('returns origin if remote could not be determined', () => {
     expect(Packages.getRemote()).toEqual('origin');

--- a/src/packages.js
+++ b/src/packages.js
@@ -9,7 +9,7 @@ module.exports = {
     pack ??= {};
     let repository = pack.repository?.url ?? pack.repository;
     if (repository) {
-      const repoUrl = repository.replace(/\.git$/, '');
+      const repoUrl = repository.replace(/^git\+/, '').replace(/\.git$/, '');
       if (!URL.canParse(repoUrl)) { return null; }
       const repoPath = new URL(repoUrl).pathname;
       const [name, owner] = repoPath.split('/').slice(-2);


### PR DESCRIPTION
Tools such as `publint` encourage the usage of `git+https://` URLs in `repository.url`. However, `ppm` doesn't like this change. Similar to stripping out the `.git` extension, this PR strips `git+` from the protocol.